### PR TITLE
New upgrade workflow opsman mlong

### DIFF
--- a/upgrading-pcf.html.md.erb
+++ b/upgrading-pcf.html.md.erb
@@ -50,7 +50,7 @@ Follow these steps to keep all installed products when you upgrade Ops Manager.
 
         <%= image_tag("./images/upgrading/compress.png") %>
 
-1. Download the latest Ops Manager VM Template from the [Pivotal Network](https://network.pivotal.io) site.
+1. Download the latest Ops Manager VM Template from the [Pivotal Network](https://network.pivotal.io/products/pivotal-cf) site.
 
 1. Record the IP address of the existing Ops Manager VM.
 


### PR DESCRIPTION
The steps in current documentation for upgrading Ops Manager are actually wrong and could cause an Operator to get stuck or devolve into troubleshooting mode. Also, the link to go download the latest Ops Manager forces an Operator to search for Ops Manager, which is buried in the PCF release. We should just link directly to PCF product page.
