### PR TITLE
Update pcf-vchs-vcloud.html.md.erb

### DIFF
--- a/pcf-vchs-vcloud.html.md.erb
+++ b/pcf-vchs-vcloud.html.md.erb
@@ -6,6 +6,7 @@ This topic is a prerequisite to [Configuring Ops Manager Director for vCloud Air
 
 This topic describes how to configure the vCloud or vCloud Air Edge Gateways Configure Services screen and install Ops Manager for your Elastic Runtime environment.
 
+Note: Pivotal Cloud Foundry does not currently support vCloud Air On Demand. 
 
 ## <a id='requirements'></a>Minimum Requirements ##
 


### PR DESCRIPTION
@mreider per our conversation the other day. The OpsMgr VM's guest customization steps fail in vCloudAir On Demand (it works as expected in the subscription service). The support case is ongoing so we've not identified a root cause, but wanted to hopefully prevent others from stumbling across the same issue.  

Thanks, 
Josh