### PR TITLE
Add permissions for uploading a stem cell.

### DIFF
--- a/pcf-aws-component-config.html.md.erb
+++ b/pcf-aws-component-config.html.md.erb
@@ -155,7 +155,9 @@ You must create an Amazon Identity and Access Management user (IAM) with the min
                 "ec2:DetachVolume",
                 "ec2:CreateSnapshot",
                 "ec2:DeleteSnapshot",
-                "ec2:DescribeSnapshots"
+                "ec2:DescribeSnapshots",
+                "ec2:RegisterImage",
+                "ec2:DeregisterImage"
             ],
             "Resource": "*"
         }


### PR DESCRIPTION
I was making the existing Jenkins tile work in AWS. One of the things I needed to do was upload a stemcell to make that happen. We need to add the image permissions to the IAM role to have that happen successfully. 