### PR TITLE
Updates to cloudformation instructions

### DIFF
--- a/cloudform-om-config.html.md.erb
+++ b/cloudform-om-config.html.md.erb
@@ -38,10 +38,10 @@ You use the information in the **Value** column of the **Outputs** tab to [confi
 1. Select **AWS Config** to open the **AWS Management Console Config** page.
 
 1. Complete the **AWS Management Console Config** page with information from the **Outputs** tab you opened previously in the AWS Console:
-    * **Access Key ID**: Use **PcfIamUserAccessKey**.
-    * **AWS Secret Key**: Use **PcfIamUserSecretAccessKey**.
-    * **VPC ID**: Use **PcfVpc**.
-    * **Key Pair Name**: Use **PcfKeyPairName**.
+    * **Access Key ID**: Use the value of **PcfIamUserAccessKey**.
+    * **AWS Secret Key**: Use the value of **PcfIamUserSecretAccessKey**.
+    * **VPC ID**: Use the value of **PcfVpc**.
+    * **Key Pair Name**: Use the value of **PcfKeyPairName**.
     * **SSH Private Key**: Open your pre-existing AWS key pair `.pem` file in a
 		text editor. Copy the contents of the `.pem` file and paste into the
 		**SSH Private Key** field.
@@ -71,15 +71,15 @@ Manager Resurrector functionality and increase Elastic Runtime availability.
     * **Blobstore Location**: Select the **Amazon S3** option.
     * **S3 Endpoint**: You must determine this value by looking up the S3 Endpoint for your AWS Region in the [Amazon Simple Storage Service endpoints table](http://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region).  Don't forget to format the endpoint address as an HTTPS URL.  
     For example, if you are using the region ***us-west-1*** then you would enter ***http://s3-us-west-1.amazonaws.com/*** in this box.
-    * **Bucket Name**: Use **PcfOpsManagerS3Bucket**.
-    * **Access Key ID**: Use **PcfIamUserAccessKey**.
-    * **AWS Secret Key**: Use **PcfIamUserSecretAccessKey**.
+    * **Bucket Name**: Use the value of **PcfOpsManagerS3Bucket**.
+    * **Access Key ID**: Use the value of **PcfIamUserAccessKey**.
+    * **AWS Secret Key**: Use the value of **PcfIamUserSecretAccessKey**.
     * **Database Location**: Select the **External MySQL Database** option.
-    * **Host**: Use **PcfRdsAddress**.
-    * **Port**: Use **PcfRdsPort**.
-    * **Username**: Use **PcfRdsUsername**.
-    * **Password**: Use **PcfRdsPassword**.
-    * **Database**: Use **PcfRdsDBName**.
+    * **Host**: Use the value of **PcfRdsAddress**.
+    * **Port**: Use the value of **PcfRdsPort**.
+    * **Username**: Use the value of **PcfRdsUsername**.
+    * **Password**: Use the value of **PcfRdsPassword**.
+    * **Database**: Use the value of **PcfRdsDBName**.
 
 1. Click **Save**.
 
@@ -89,7 +89,7 @@ Manager Resurrector functionality and increase Elastic Runtime availability.
 
 1. Select **Create Availability Zones**.
 
-1. Enter **PcfPrivateSubnetAvailabilityZone** from the **Outputs** tab in the AWS Console.
+1. Enter the value of **PcfPrivateSubnetAvailabilityZone** from the **Outputs** tab in the AWS Console.
 
 1. Select **Assign Availability Zones**.
 
@@ -104,8 +104,8 @@ Manager Resurrector functionality and increase Elastic Runtime availability.
 1. Select **Create Networks**.
 
 1. Complete the **Create Networks** page with information from the **Outputs** tab in the AWS Console:
-    * **Name**: Use **PcfNetwork** (or any other name you prefer).
-    * **VPC Subnet ID**: Use **PcfPrivateSubnetId**.
+    * **Name**: Use the value of **PcfNetwork** (or choose any other name you prefer).
+    * **VPC Subnet ID**: Use the value of **PcfPrivateSubnetId**.
     * **Subnet (CIDR Range)**: Use **10.0.16.0/20**.
     * **Excluded IP Ranges**: Use **10.0.16.1-10.0.16.9**.
     * **DNS**: Use **10.0.0.2**.

--- a/cloudform-template.html.md.erb
+++ b/cloudform-template.html.md.erb
@@ -15,7 +15,7 @@ After completing this procedure, complete all of the steps in the following topi
 * [Configuring Ops Manager Director on AWS CloudFormation](./cloudform-om-config.html)
 * [Installing Elastic Runtime on AWS CloudFormation](./cloudform-er-config.html)
 
-1. Download the **PCF Ops Manager CloudFormation Template** from [Pivotal Network](https://network.pivotal.io/).
+1. Download the **Pivotal Cloud Foundry Ops Manager CloudFormation Template** from the Pivotal Cloud Foundry section of [Pivotal Network](https://network.pivotal.io/).
 
 1. Log in to the [AWS Console](https://console.aws.amazon.com/).
 


### PR DESCRIPTION
Matt Reider and I are concerned that if we say something like:

**Access Key ID**: Use **PcfIamUserAccessKey**

then readers may believe they are supposed to enter the literal string "PcfIamUserAccessKey" in the box.

Therefore, I added the words "the value of" in front of each variable, like this:

**Access Key ID**: Use the value of **PcfIamUserAccessKey**