### PR TITLE
Added docs for 'Advanced Infrastructure Config' section

### DIFF
--- a/openstack-om-config.html.md.erb
+++ b/openstack-om-config.html.md.erb
@@ -66,7 +66,22 @@ information:
 
     <%= image_tag("openstack/om-openstack-config.png") %>
 
-## <a id='director-config'></a>Step 3: Complete the Director Config Page ##
+
+
+## <a id='openstack-config'></a>Step 3 (Optional): Complete the Advanced Config Page ##
+
+1. In Ops Manager, select **Advanced Infrastructure Config**.
+
+1. If your OpenStack environment requires specific connection options, enter them in the Connection Options field in JSON format.  For example:  
+
+  `'connection_options' => { 'read_timeout' => 200 }`
+
+  (This is an advanced option.  Most users will leave this field blank.)
+
+1.  Click **Save**.
+
+
+## <a id='director-config'></a>Step 4: Complete the Director Config Page ##
 
 1. In the left navigation of your OpenStack dashboard, click **Project > Compute > Access & Security**. Select the **API Access** tab.
 
@@ -99,7 +114,7 @@ file:
 
     <%= image_tag("openstack/om-director-config.png") %>
 
-## <a id='az-config'></a>Step 4: Complete the Availability Zones Pages ##
+## <a id='az-config'></a>Step 5: Complete the Availability Zones Pages ##
 
 1. In Ops Manager, select **Create Availability Zones**.
 
@@ -119,7 +134,7 @@ availability zone that you just created.
 
     <%= image_tag("openstack/assign-az.png") %>
 
-## <a id='networks-config'></a>Step 5: Complete the Networks Pages ##
+## <a id='networks-config'></a>Step 6: Complete the Networks Pages ##
 
 1. In the left navigation of your OpenStack dashboard, click **Project > Network > Networks**.
 
@@ -154,7 +169,7 @@ network settings.
 
     <%= image_tag("openstack/om-assign-networks.png") %>
 
-## <a id='complete'></a>Step 6: Complete Ops Manager Director Installation ##
+## <a id='complete'></a>Step 7: Complete Ops Manager Director Installation ##
 
 1. Click the **Installation Dashboard** link to return to the Installation Dashboard.
 


### PR DESCRIPTION
Ops Man is adding a new section next week in OM 1.5.3 called "Advanced Infrastructure Config" (only on  OpenStack).  This PR adds documentation for the new section.