### PR TITLE
Bugfix: ssh anchor conflict

### DIFF
--- a/trouble-advanced.html.md.erb
+++ b/trouble-advanced.html.md.erb
@@ -314,7 +314,7 @@ For each difference detected, `bosh cloudcheck` offers repair options:
 	- Delete VM (unless it has persistent disk)
 </pre>
 
-### <a id='ssh'></a>BOSH SSH ###
+### <a id='bosh-ssh'></a>BOSH SSH ###
 
 Use `bosh ssh` to SSH into the VMs in your deployment.
 


### PR DESCRIPTION
The anchor, "ssh" was used twice, once to refer to SSH to OpsManager Director, the second time to get to describe how to use BOSH's ssh.