### PR TITLE
Updated the name of the link as seen in the Pivotal Network.

### DIFF
--- a/cloudform-template.html.md.erb
+++ b/cloudform-template.html.md.erb
@@ -18,7 +18,7 @@ infrastructure that you need to deploy PCF to AWS.
 
 1. Select <b>Elastic Runtime</b>. From the <b>Releases</b> drop-down menu, select the release that you wish to install.
 
-1. Download the **PCF Elastic Runtime and Ops Manager CloudFormation Template for AWS**. 
+1. Download the **PCF 1.6 Cloudformation script for AWS**. 
 
 1. Save the file as `pcf.json`.
 
@@ -78,7 +78,7 @@ $ aws iam upload-server-certificate \
 
     <%= image_tag("cloudform/uploadtemplate.png") %>
 
-1. Click **Browse**. Browse to and select the `pcf.json`, the **Pivotal Cloud Foundry&reg; Elastic Runtime and Ops Manager CloudFormation Template for AWS** file that you downloaded. Click **Next**.
+1. Click **Browse**. Browse to and select the `pcf.json`, the **Pivotal Cloud Foundry&reg; Cloudformation script for AWS** file that you downloaded. Click **Next**.
 
 1. On the next screen, name the stack `pcf-stack`. 
 


### PR DESCRIPTION
Pivotal Network has renamed the links as of PCF 1.6.x Elastic Runtime:
https://network.pivotal.io/products/elastic-runtime

We should be consistent with the Pivotal Network naming convention.
