### PR TITLE
Canonical's Priority for Ubuntu packages trumps CVSS score

### DIFF
--- a/pcf-security.md.erb
+++ b/pcf-security.md.erb
@@ -34,7 +34,7 @@ PCF has many customer stakeholders who need to know about security updates. When
 
 ##<a id='classes'></a>Classes of Vulnerabilities ##
 
-Attackers can exploit vulnerabilities to compromise user data and processing resources. This can affect data confidentiality, integrity, and availability to different degrees. Pivotal follows [Common Vulnerability Scoring System v3.0 standards](https://www.first.org/cvss/specification-document) when assessing severity.
+Attackers can exploit vulnerabilities to compromise user data and processing resources. This can affect data confidentiality, integrity, and availability to different degrees. For vulnerabilities related to Ubuntu provided packages, Pivotal follows [Canonical's priority levels](http://people.canonical.com/~ubuntu-security/cve/priority.html). For other vulerabilities, Pivotal follows [Common Vulnerability Scoring System v3.0 standards](https://www.first.org/cvss/specification-document) when assessing severity.
 
 Pivotal reports the severity of vulnerabilities using the following severity classes:
 


### PR DESCRIPTION
We use Canonical's "Priority" for Ubuntu related vulnerabilities rather
than CVSS.

The NVD's CVSS score and related "Severity" are based on a general (i.e.
platform-less) evaluation of risk exposure.  Canonical's "Priority" is
an evaluation of risk in the context of their platform.