### PR TITLE
Update bootstrap docs to show usage of errand

### DIFF
--- a/mysql_bootstrap_ert.html.md.erb
+++ b/mysql_bootstrap_ert.html.md.erb
@@ -231,8 +231,6 @@ Next, complete the bootstrapping process in the following section.
             | mysql-partition-a813339fde9330e9b905/0           | failing | mysql-partition-a813339fde9330e9b905           | 10.0.16.55 |
             | mysql-partition-a813339fde9330e9b905/1           | failing | mysql-partition-a813339fde9330e9b905           | 10.0.16.56 |
             | mysql-partition-a813339fde9330e9b905/2           | failing | mysql-partition-a813339fde9330e9b905           | 10.0.16.57 |
-            | proxy-partition-a813339fde9330e9b905/0           | running | proxy-partition-a813339fde9330e9b905           | 10.0.16.59 |
-            | proxy-partition-a813339fde9330e9b905/1           | running | proxy-partition-a813339fde9330e9b905           | 10.0.16.60 |
             +--------------------------------------------------+---------+------------------------------------------------+------------+
 
         In this situation, it is OK to immediately try the bootstrap errand:
@@ -258,6 +256,144 @@ Next, complete the bootstrapping process in the following section.
         ```
 
         There are times when this won't work immediately. Unfortunately, sometimes it is best to wait and try again a few minutes later.
+        
+    ### <a id="vms-terminated"></a>Scenario 2: Virtual Machines Terminated or Lost ###
+    1. In more severe circumstances, such as power failure, it's possible that all of your VMs have been lost. They'll need to be recreated before you can begin to recover the cluster. In this case, you'll see the nodes appear as `unknown/unknown` in the BOSH output.
+
+            $ bosh instances
+            +--------------------------------------------------+--------------------+------------------------------------------------+------------+
+            | Instance                                         | State              | Resource Pool                                  | IPs        |
+            +--------------------------------------------------+--------------------+------------------------------------------------+------------+
+            | unknown/unknown                                  | unresponsive agent |                                                |            |
+            +--------------------------------------------------+--------------------+------------------------------------------------+------------+
+            | unknown/unknown                                  | unresponsive agent |                                                |            |
+            +--------------------------------------------------+--------------------+------------------------------------------------+------------+
+            | unknown/unknown                                  | unresponsive agent |                                                |            |
+            +--------------------------------------------------+--------------------+------------------------------------------------+------------+
+
+        #### <a id="vm-recovery"></a>VM Recovery ####
+
+        VM Recovery is best left to OpsManager by configuring the VM [Resurrector](http://docs.pivotal.io/pivotalcf/customizing/resurrector.html#enabling). If enabled, the system will notice that the VMs are gone, and automatically attempt to recreate them. You will be able to see evidence of that by seeing the scan-and-fix job in the output of `bosh tasks recent --no-filter`.
+
+            $ bosh tasks recent --no-filter
+            +-----+------------+-------------------------+----------+--------------------------------------------+---------------------------------------------------+
+            | #   | State      | Timestamp               | User     | Description                                | Result                                            |
+            +-----+------------+-------------------------+----------+--------------------------------------------+---------------------------------------------------+
+            | 123 | queued     | 2016-01-08 00:18:07 UTC | director | scan and fix                               |                                                   |
+
+        If you have not configured the Resurrector to run automatically, you can also run the BOSH Cloud Check interactive command `bosh cck` to delete any placeholder VMs. If given the option, select **Delete VM reference**.
+
+            $ bosh cck
+
+              Acting as user 'director' on deployment 'cf-e82cbf44613594d8a155' on 'p-bosh-30c19bdd43c55c627d70'
+            Performing cloud check...
+
+            Director task 34
+              Started scanning 22 vms
+              Started scanning 22 vms > Checking VM states. Done (00:00:10)
+              Started scanning 22 vms > 19 OK, 0 unresponsive, 3 missing, 0 unbound, 0 out of sync. Done (00:00:00)
+                 Done scanning 22 vms (00:00:10)
+
+              Started scanning 10 persistent disks
+              Started scanning 10 persistent disks > Looking for inactive disks. Done (00:00:02)
+              Started scanning 10 persistent disks > 10 OK, 0 missing, 0 inactive, 0 mount-info mismatch. Done (00:00:00)
+                 Done scanning 10 persistent disks (00:00:02)
+
+            Task 34 done
+
+            Started   2015-11-26 01:42:42 UTC
+            Finished  2015-11-26 01:42:54 UTC
+            Duration  00:00:12
+
+            Scan is complete, checking if any problems found.
+
+            Found 3 problems
+
+            Problem 1 of 3: VM with cloud ID `i-afe2801f' missing.
+                1. Skip for now
+                2. Recreate VM
+                3. Delete VM reference
+            Please choose a resolution [1 - 3]: 3
+
+            Problem 2 of 3: VM with cloud ID `i-36741a86' missing.
+                1. Skip for now
+                2. Recreate VM
+                3. Delete VM reference
+            Please choose a resolution [1 - 3]: 3
+
+            Problem 3 of 3: VM with cloud ID `i-ce751b7e' missing.
+                1. Skip for now
+                2. Recreate VM
+                3. Delete VM reference
+            Please choose a resolution [1 - 3]: 3
+
+            Below is the list of resolutions you've provided
+            Please make sure everything is fine and confirm your changes
+
+                1. VM with cloud ID `i-afe2801' missing.
+                 Delete VM reference
+
+                2. VM with cloud ID `i-36741a86' missing.
+                 Delete VM reference
+
+                3. VM with cloud ID `i-ce751b7e' missing.
+                 Delete VM reference
+
+            Apply resolutions? (type 'yes' to continue): yes
+            Applying resolutions...
+
+            Director task 35
+              Started applying problem resolutions
+              Started applying problem resolutions > missing_vm 11: Delete VM reference. Done (00:00:00)
+              Started applying problem resolutions > missing_vm 27: Delete VM reference. Done (00:00:00)
+              Started applying problem resolutions > missing_vm 26: Delete VM reference. Done (00:00:00)
+                 Done applying problem resolutions (00:00:00)
+
+            Task 35 done
+
+            Started   2015-11-26 01:47:08 UTC
+            Finished  2015-11-26 01:47:08 UTC
+            Duration  00:00:00
+            Cloudcheck is finished
+
+        By watching `bosh instances` you'll see the VMs transition from `unresponsive agent` to `starting`. Ultimately, two will appear as `failing`, this is OK.
+
+            $ bosh instances
+            [...]
+            +--------------------------------------------------+----------+------------------------------------------------+------------+
+            | mysql-partition-e97dae91e44681e0b543/0           | starting | mysql-partition-e97dae91e44681e0b543           | 10.0.16.60 |
+            | mysql-partition-e97dae91e44681e0b543/1           | failing  | mysql-partition-e97dae91e44681e0b543           | 10.0.16.61 |
+            | mysql-partition-e97dae91e44681e0b543/2           | failing  | mysql-partition-e97dae91e44681e0b543           | 10.0.16.62 |
+            +--------------------------------------------------+----------+------------------------------------------------+------------+
+
+        Do not proceed to the next step until all three VMs are in the `starting`/`failing` state.
+
+        #### <a id="updating-manifest"></a>Update the BOSH configuration ####
+
+        In standard deployment, BOSH is configured to manage the cluster in a specific manner. You must change that configuration in order for the bootstrap errand to perform its work. Follow this process to make it possible for the bootstrap errand to succeed.
+
+        1. Log into the BOSH director
+        1. Target the correct deployment
+        1. `bosh edit deployment`
+            * Search for the jobs section: `jobs`
+            * Search for the mysql-partition: `mysql-partition`
+            * Search for the update section: `update`
+            * Change max\_in\_flight to `3`.
+            * Below the `max_in_flight` line, add a line: `canaries: 0`
+        1. `bosh deploy`
+
+        #### <a id="run-the-errand"></a>Run the bootstrap errand ####
+        1. `bosh run errand bootstrap`
+        1. Validate that the errand completes successfully.
+            - Some instances may still appear as `failing`. It's OK to proceed to the next step.
+
+        #### <a id="reset-deployment"></a>Restore the BOSH configuration ####
+        1. `bosh edit deployment`
+        1. Re-set `canaries` to 1, `max_in_flight` to 1, and `serial` to true in the same manner as above.
+        1. `bosh deploy`
+        1. Validate that all mysql instances are in `running` state.
+
+        <p class="note"><strong>Note:</strong> It is critical that you run all of the steps. If you do not re-set the values in the BOSH manifest, the status of the jobs will not be reported correctly and can lead to troubles in future deploys.</p>
 
 ---
 

--- a/mysql_bootstrap_ert.html.md.erb
+++ b/mysql_bootstrap_ert.html.md.erb
@@ -13,30 +13,27 @@ owner: RelEng
 
 #### Symptoms of Lost Quorum
 
-<ul>
-  <li>[All nodes appear "Unhealthy" on the proxy dashboard.](quorum-lost.png)</li>
-  <li>All responsive nodes report the value of `wsrep_cluster_status` as `non-Primary`.</li>
-</ul>
+* All nodes appear "Unhealthy" on the proxy dashboard:
+  <img src="https://docs.pivotal.io/edge/p-mysql/quorum-lost.png">
+* All responsive nodes report the value of `wsrep_cluster_status` as `non-Primary`.
 
-    <pre class="terminal">
-    mysql> SHOW STATUS LIKE 'wsrep_cluster_status';
-    +----------------------+-------------+
-    | Variable_name        | Value       |
-    +----------------------+-------------+
-    | wsrep_cluster_status | non-Primary |
-    +----------------------+-------------+
-    </pre>
+<pre class="terminal">
+mysql> SHOW STATUS LIKE 'wsrep_cluster_status';
++----------------------+-------------+
+| Variable_name        | Value       |
++----------------------+-------------+
+| wsrep_cluster_status | non-Primary |
++----------------------+-------------+
+</pre>
 
-<ul>
-  <li>All responsive nodes respond with `ERROR 1047` when queried with most statement types.</li>
-</ul>
+* All responsive nodes respond with `ERROR 1047` when queried with most statement types.
 
-    <pre class="terminal">
-    mysql> select * from mysql.user;
-    ERROR 1047 (08S01) at line 1: WSREP has not yet prepared node for application use
-    </pre>
+<pre class="terminal">
+mysql> select * from mysql.user;
+ERROR 1047 (08S01) at line 1: WSREP has not yet prepared node for application use
+</pre>
 
-See [MySQL Cluster Behavior](https://github.com/cloudfoundry/cf-mysql-release/blob/master/docs/cluster-behavior.md) for more details about determining cluster state.
+See [MySQL Cluster Behavior](https://docs.pivotal.io/edge/p-mysql/cluster-behavior.html) for more details about determining cluster state.
 
 <p>In the event that all of the MySQL virtual machines (VMs) are terminated, the cluster will not automatically restart as it has by definition lost quorum. For example, this process is necessary when all Elastic Runtime VMs are removed on AWS. Follow the below procedure to recreate the lost VMs before completing the bootstrapping process to recover the cluster.</p>
 

--- a/mysql_bootstrap_ert.html.md.erb
+++ b/mysql_bootstrap_ert.html.md.erb
@@ -209,6 +209,60 @@ Next, complete the bootstrapping process in the following section.
 
 <p class='note'><strong>Note</strong>: Bootstrapping requires you to run commands from the <a href="./../customizing/index.html">Ops Manager Director</a>. Follow the instructions to use the <a href="./../customizing/trouble-advanced.html#prepare">BOSH CLI</a> for command-line access.</p>
 
+## <a id="assisted-bootstrap"></a>Assisted Bootstrap ##
+
+1. Elastic Runtime versions 1.7.0 and later include a [BOSH errand](http://bosh.io/docs/jobs.html#jobs-vs-errands) to automate the process of bootstrapping. It is still necessary to manually initiate the bootstrap process, but using this errand reduces the number of manual steps necessary to complete the process.
+
+    In most cases, running the errand is sufficient, however there are some conditions which require additional steps.
+
+    #### <a id="how-it-works"></a>How it works ####
+
+    The bootstrap errand simply automates the steps in the manual bootstrapping process documented below. It finds the node with the highest transaction sequence number, and asks it to start up by itself (i.e. in bootstrap mode), then asks the remaining nodes to join the cluster.
+
+    ### <a id="cluster-disrupted"></a>Scenario 1: Virtual Machines running, Cluster Disrupted ###
+
+    1. If the nodes are up and running, but the cluster has been disrupted, the jobs will appear as `failing.` The output of `bosh instances` will look like this:
+
+            $ bosh instances
+            [...]
+            +--------------------------------------------------+---------+------------------------------------------------+------------+
+            | Instance                                         | State   | Resource Pool                                  | IPs        |
+            +--------------------------------------------------+---------+------------------------------------------------+------------+
+            | mysql-partition-a813339fde9330e9b905/0           | failing | mysql-partition-a813339fde9330e9b905           | 10.0.16.55 |
+            | mysql-partition-a813339fde9330e9b905/1           | failing | mysql-partition-a813339fde9330e9b905           | 10.0.16.56 |
+            | mysql-partition-a813339fde9330e9b905/2           | failing | mysql-partition-a813339fde9330e9b905           | 10.0.16.57 |
+            | proxy-partition-a813339fde9330e9b905/0           | running | proxy-partition-a813339fde9330e9b905           | 10.0.16.59 |
+            | proxy-partition-a813339fde9330e9b905/1           | running | proxy-partition-a813339fde9330e9b905           | 10.0.16.60 |
+            +--------------------------------------------------+---------+------------------------------------------------+------------+
+
+        In this situation, it is OK to immediately try the bootstrap errand:
+
+        1. Log into the BOSH director
+        1. Select the correct deployment
+        1. `bosh run errand bootstrap`
+
+        You will see many lines of output, eventually followed by:
+
+        ```
+        Bootstrap errand completed
+
+        [stderr]
+        + echo 'Started bootstrap errand ...'
+        + JOB_DIR=/var/vcap/jobs/bootstrap
+        + CONFIG_PATH=/var/vcap/jobs/bootstrap/config/config.yml
+        + /var/vcap/packages/bootstrap/bin/cf-mysql-bootstrap -configPath=/var/vcap/jobs/bootstrap/config/config.yml
+        + echo 'Bootstrap errand completed'
+        + exit 0
+
+        Errand `bootstrap' completed successfully (exit code 0)
+        ```
+
+        There are times when this won't work immediately. Unfortunately, sometimes it is best to wait and try again a few minutes later.
+
+---
+
+## <a id="manual-bootstrap"></a>Manual Bootstrap ##
+
 Bootstrapping identifies the primary node to synchronize all of the nodes in a cluster. You must run all of the steps in this section to ensure successful future deployments and accurate reporting of the status of your jobs.
 
 1. Follow the [Bootstrap](https://docs.pivotal.io/p-mysql/bootstrapping.html) process to restart your MySQL cluster.
@@ -238,7 +292,8 @@ Bootstrapping identifies the primary node to synchronize all of the nodes in a c
     1. Set `update.max_in_flight` to `1`.
     1. Set `update.serial` to `true`.
 
-1. Run `bosh deploy` to apply these changes.
+1. Run `bosh deploy` to apply these changes. Note, if you get a 503 error (like `Sending stop request to monit: Request failed, response: Response{ StatusCode: 503, Status: '503 Service Unavailable' }`),
+it means that monit is still trying to stop the vms. Please wait a few minutes and try this step again.
 
 ## <a id='common'></a>Resolve Common Issues ##
 

--- a/mysql_bootstrap_ert.html.md.erb
+++ b/mysql_bootstrap_ert.html.md.erb
@@ -17,21 +17,21 @@ owner: RelEng
   <img src="https://docs.pivotal.io/edge/p-mysql/quorum-lost.png">
 * All responsive nodes report the value of `wsrep_cluster_status` as `non-Primary`.
 
-<pre class="terminal">
-mysql> SHOW STATUS LIKE 'wsrep_cluster_status';
-+----------------------+-------------+
-| Variable_name        | Value       |
-+----------------------+-------------+
-| wsrep_cluster_status | non-Primary |
-+----------------------+-------------+
-</pre>
+    <pre class="terminal">
+    mysql> SHOW STATUS LIKE 'wsrep_cluster_status';
+    +----------------------+-------------+
+    | Variable_name        | Value       |
+    +----------------------+-------------+
+    | wsrep_cluster_status | non-Primary |
+    +----------------------+-------------+
+    </pre>
 
 * All responsive nodes respond with `ERROR 1047` when queried with most statement types.
 
-<pre class="terminal">
-mysql> select * from mysql.user;
-ERROR 1047 (08S01) at line 1: WSREP has not yet prepared node for application use
-</pre>
+    <pre class="terminal">
+    mysql> select * from mysql.user;
+    ERROR 1047 (08S01) at line 1: WSREP has not yet prepared node for application use
+    </pre>
 
 See [MySQL Cluster Behavior](https://docs.pivotal.io/edge/p-mysql/cluster-behavior.html) for more details about determining cluster state.
 
@@ -187,7 +187,7 @@ See [MySQL Cluster Behavior](https://docs.pivotal.io/edge/p-mysql/cluster-behavi
     Jobs
     mysql-partition-f8abb6ac43ccc9fe16d7
       update
-        ± max_in_flight:
+        ± max\_in\_flight:
           - 1
           + 3
         + canaries: 0<br>
@@ -253,15 +253,17 @@ Next, complete the bootstrapping process in the following section.
 
     1. If the nodes are up and running, but the cluster has been disrupted, the jobs will appear as `failing.` The output of `bosh instances` will look like this:
 
-            $ bosh instances
-            [...]
-            +--------------------------------------------------+---------+------------------------------------------------+------------+
-            | Instance                                         | State   | Resource Pool                                  | IPs        |
-            +--------------------------------------------------+---------+------------------------------------------------+------------+
-            | mysql-partition-a813339fde9330e9b905/0           | failing | mysql-partition-a813339fde9330e9b905           | 10.0.16.55 |
-            | mysql-partition-a813339fde9330e9b905/1           | failing | mysql-partition-a813339fde9330e9b905           | 10.0.16.56 |
-            | mysql-partition-a813339fde9330e9b905/2           | failing | mysql-partition-a813339fde9330e9b905           | 10.0.16.57 |
-            +--------------------------------------------------+---------+------------------------------------------------+------------+
+        <pre class="terminal">
+        $ bosh instances
+        [...]
+        +--------------------------------------------------+---------+------------------------------------------------+------------+
+        | Instance                                         | State   | Resource Pool                                  | IPs        |
+        +--------------------------------------------------+---------+------------------------------------------------+------------+
+        | mysql-partition-a813339fde9330e9b905/0           | failing | mysql-partition-a813339fde9330e9b905           | 10.0.16.55 |
+        | mysql-partition-a813339fde9330e9b905/1           | failing | mysql-partition-a813339fde9330e9b905           | 10.0.16.56 |
+        | mysql-partition-a813339fde9330e9b905/2           | failing | mysql-partition-a813339fde9330e9b905           | 10.0.16.57 |
+        +--------------------------------------------------+---------+------------------------------------------------+------------+
+        </pre>
 
         In this situation, it is OK to immediately try the bootstrap errand:
 

--- a/mysql_bootstrap_ert.html.md.erb
+++ b/mysql_bootstrap_ert.html.md.erb
@@ -5,7 +5,40 @@ owner: RelEng
 
 <strong><%= modified_date %></strong>
 
-This topic describes the manual procedure for recovering a terminated Elastic Runtime cluster. In the event that all of the MySQL virtual machines (VMs) are terminated, the cluster will not automatically restart. For example, this process is necessary when all Elastic Runtime VMs are removed on AWS.  Follow this procedure to recreate the lost VMs before completing the bootstrapping process to recover the cluster.
+<p>This topic describes the manual procedure for recovering a terminated Elastic Runtime cluster, via a process known as bootstrapping.</p>
+
+## When to Bootstrap
+
+<p>Bootstrapping is only required when the cluster has lost quorum. Quorum is lost when less than half of the nodes can communicate with each other (for longer than the configured grace period). If quorum has <strong>not</strong> been lost, individual unhealthy nodes should automatically rejoin the cluster once repaired (error resolved, node restarted, or connectivity restored). </p>
+
+#### Symptoms of Lost Quorum
+
+<ul>
+  <li>[All nodes appear "Unhealthy" on the proxy dashboard.](quorum-lost.png)</li>
+  <li>All responsive nodes report the value of `wsrep_cluster_status` as `non-Primary`.</li>
+</ul>
+
+    <pre class="terminal">
+    mysql> SHOW STATUS LIKE 'wsrep_cluster_status';
+    +----------------------+-------------+
+    | Variable_name        | Value       |
+    +----------------------+-------------+
+    | wsrep_cluster_status | non-Primary |
+    +----------------------+-------------+
+    </pre>
+
+<ul>
+  <li>All responsive nodes respond with `ERROR 1047` when queried with most statement types.</li>
+</ul>
+
+    <pre class="terminal">
+    mysql> select * from mysql.user;
+    ERROR 1047 (08S01) at line 1: WSREP has not yet prepared node for application use
+    </pre>
+
+See [MySQL Cluster Behavior](https://github.com/cloudfoundry/cf-mysql-release/blob/master/docs/cluster-behavior.md) for more details about determining cluster state.
+
+<p>In the event that all of the MySQL virtual machines (VMs) are terminated, the cluster will not automatically restart as it has by definition lost quorum. For example, this process is necessary when all Elastic Runtime VMs are removed on AWS. Follow the below procedure to recreate the lost VMs before completing the bootstrapping process to recover the cluster.</p>
 
 ## <a id='mysql'></a>Prepare MySQL VMs for Bootstrapping  ##
 
@@ -241,7 +274,7 @@ Next, complete the bootstrapping process in the following section.
 
         You will see many lines of output, eventually followed by:
 
-        ```
+        <pre class="terminal">
         Bootstrap errand completed
 
         [stderr]
@@ -253,10 +286,9 @@ Next, complete the bootstrapping process in the following section.
         + exit 0
 
         Errand `bootstrap' completed successfully (exit code 0)
-        ```
+        </pre>
 
-        There are times when this won't work immediately. Unfortunately, sometimes it is best to wait and try again a few minutes later.
-        
+        <p>There are times when this won't work immediately. Unfortunately, sometimes it is best to wait and try again a few minutes later.</p>
     ### <a id="vms-terminated"></a>Scenario 2: Virtual Machines Terminated or Lost ###
     1. In more severe circumstances, such as power failure, it's possible that all of your VMs have been lost. They'll need to be recreated before you can begin to recover the cluster. In this case, you'll see the nodes appear as `unknown/unknown` in the BOSH output.
 


### PR DESCRIPTION
In a recent release of p-mysql, we've started including a bootstrap errand to help recover from system outages. ERT also uses p-mysql in an embedded context, and thus suffers from the same difficult process for recovering from failure.

This change updates the ERT instructions to also use this aid.

/cc @mfine30 @aditya87 @aaronshurley @fkotsian
