### PR TITLE
Update Apps Manager address

### DIFF
--- a/pcf_azure.html.md.erb
+++ b/pcf_azure.html.md.erb
@@ -118,7 +118,7 @@ Choose which Azure location you want to deploy to.
 	<%= image_tag("azure/image_2.png") %>
 
 1. Connect to the PCF Apps Manager:
-	* https://apps.system.[CF-IP-ADDRESS].xip.io
+	* https://apps.system.[CF-IP-ADDRESS].cf.pcfazure.com
 	* user name=admin
 	* password=obtained in step 4.
 


### PR DESCRIPTION
no longer using xip.io for wildcard domain, updated address accordingly.