### PR TITLE
Change in the phrasing of what we support

### DIFF
--- a/openstack.html.md.erb
+++ b/openstack.html.md.erb
@@ -5,7 +5,7 @@ owner: Ops Manager
 
 <strong><%= modified_date %></strong>
 
-This guide describes how to install [Pivotal Cloud Foundry&reg;](https://network.pivotal.io/products/pivotal-cf) (PCF) on a Mirantis distribution of OpenStack.
+This guide describes how to install [Pivotal Cloud Foundry&reg;](https://network.pivotal.io/products/pivotal-cf) (PCF) on OpenStack Juno and Kilo distributions.
 
 
 ## Install PCF on OpenStack ##
@@ -20,7 +20,7 @@ Complete the following procedures to install PCF on OpenStack:
 
 ## Supported Versions ##
 
-Pivotal's automated testing environments currently run on Mirantis OpenStack 6.1 (Juno), 7.0 and 8.0. Pivotal Cloud Foundry&reg; has also been installed on OpenStack releases and distributions based on Havana, Icehouse, Juno, Kilo (Keystone v2), and Liberty from different vendors including Canonical, EMC, Red Hat, and SUSE. The nature of OpenStack as a collection of interoperable components requires OpenStack expertise to troubleshoot issues that may occur when installing Pivotal Cloud Foundry&reg; on particular releases and distributions.
+Pivotal's automated testing environments have been built using OpenStack releases and distributions based on Havana, Icehouse, Juno, Kilo (Keystone v2, and v3), and Liberty from different vendors including Canonical, EMC, Mirantis, Red Hat, and SUSE. The nature of OpenStack as a collection of interoperable components requires OpenStack expertise to troubleshoot issues that may occur when installing Pivotal Cloud Foundry&reg; on particular releases and distributions.
 
 ## Prerequisites ##
 


### PR DESCRIPTION
There are enough installations on different vendor distributions that I am removing the phrasing around Mirantis, and replacing it with more generic phrasing.