### PR TITLE
Clarified upgrade process from 1.6 to 1.7.

### DIFF
--- a/upgrading-products.html.md.erb
+++ b/upgrading-products.html.md.erb
@@ -74,7 +74,7 @@ This section describes how to upgrade individual products like Pivotal Cloud Fou
 <div class="note"><strong>Note</strong>: <a href="http://docs.pivotal.io/p-identity/index.html">The Single Sign-On service tile</a> operates in lockstep with Pivotal Elastic Runtime.
     <ul><li> The SSO v1.0.x tiles are compatible with PCF v1.6.x </li>
     <li> The SSO v1.1.x tiles are compatible with PCF v1.7.x </li></ul>
-If you are a customer upgrading from PCF 1.6 to PCF 1.7 and you are using SSO v1.0.x, you must update to the SSO v1.1.0 service tile before proceeding with the upgrade.</div>
+If you are a customer upgrading from PCF 1.6 to PCF 1.7 and you are using SSO v1.0.x, you must update SSO v1.1.0 service tile at the same time with the ERT upgrade.</div>
 
 1. Browse to [Pivotal Network](https://network.pivotal.io/) and sign in.
 
@@ -115,4 +115,3 @@ downloaded.
 
 
 * Ops Manager 1.7 defines specific instance types instead of custom sizes for vSphere or vCloud. Each instance adopts an instance type that is the closest match to its previous custom size for CPU, memory, and disk space. You can modify the automatically selected instance size by selecting a different <code>type</code> under <strong>Resource Config</strong> for each of your installed tiles.
-


### PR DESCRIPTION
We need to clarify this step. The SSO (1.0.x) tile needs to be updated (to 1.1.x) in the same "Update" step with ERT update from 1.6.x to 1.7.x

