### PR TITLE
Fixes issue with DNS and NTP values in GCP OM config

### DIFF
--- a/gcp-om-config.html.md.erb
+++ b/gcp-om-config.html.md.erb
@@ -59,7 +59,7 @@ This topic describes how to configure the Ops Manager Director for Pivotal Cloud
 
     <%= image_tag("gcp/director_gcp.png") %>
 
-1. In the **NTP Servers (comma delimited)** field, enter `metadata.google.internal`.
+1. In the **NTP Servers (comma delimited)** field, enter `169.254.169.254`.
 
 1. (Optional) If you are using [JMX Bridge](./../customizing/use-metrics.html), enter your **Metrics IP Address**.
 
@@ -121,7 +121,8 @@ Manager Resurrector functionality and increase Elastic Runtime availability.
     * **Google Network Name**: Enter the network, subnet and region names of the Google Network you created in [Preparing to Deploy PCF on GCP](./gcp-prepare-env.html#create_network). The format is NETWORK-NAME/SUBNET-NAME/REGION-NAME.
     * For **CIDR**, enter `10.0.0.0/20`. Ops Manager deploy VMs to this CIDR block. 
     * For **Reserved IP Ranges**, enter `10.0.0.1-10.0.0.9`. Ops Manager avoids deploying VMs to any IP address in this range. 
-    * Enter `10.0.0.1` for both **DNS** and **Gateway**.
+    * Enter `8.8.8.8` for DNS.
+    * Enter `10.0.0.1` for **Gateway**.
 
     <p class="note"><strong>Note</strong>: If you are using multiple Availability Zones, you must add a new network with at least one subnet for each Availability Zone.</p>
     <%= image_tag("cloudform/create-networks.png") %>


### PR DESCRIPTION
The current configuration for these values does not work for a couple of reasons.

1) OpsManager is going to want to verify the wildcard domains a user enters into the ERT configuration using each DNS server configured in the BOSH Director tile. So, because the OpsManager is likely to be deployed into a separate subnet from the PCF ERT deployment, it will be unable to reach the DNS server if it is the gateway for the subnet. So, we would be better off setting it to a public DNS server like Google's DNS at 8.8.8.8.

2) Once we switch to using an external DNS server, we will no longer be able to resolve the `metadata.google.internal` hostname. This hostname is not publicly registered, and will not resolve if we use Google's DNS at 8.8.8.8. So, we should not use the hostname, but instead switch to specifying the IP address of the metadata server so that we don't even need DNS to setup NTP.