### PR TITLE
Updates Pivotal MySQL restore instructions

### DIFF
--- a/backup-restore/restore-pcf.html.md.erb
+++ b/backup-restore/restore-pcf.html.md.erb
@@ -246,9 +246,19 @@ Restoring from a backup is the same whether one or multiple databases were backe
   $ ssh vcap@YOUR-MYSQL-VM-IP
   </pre>
 
+1. Use the MySQL password and IP address to enable the creation of tables using any storage engine.
+  <pre class='terminal'>
+  $ mysql -h YOUR-MYSQL-SERVER-IP -u root -p -e "SET GLOBAL enforce_storage_engine=NULL;"
+  </pre>
+
 1. Use the MySQL password and IP address to restore the MySQL database by running the following command.
   <pre class='terminal'>
   $ mysql -h YOUR-MYSQL-SERVER-IP -u root -p < ~/.user_databases.sql
+  </pre>
+
+1. Use the MySQL password and IP address to restore original storage engine restriction.
+  <pre class='terminal'>
+  $ mysql -h YOUR-MYSQL-SERVER-IP -u root -p -e "SET GLOBAL enforce_storage_engine='InnoDB';"
   </pre>
 
 1. Log in to the MySQL client and flush privileges.


### PR DESCRIPTION
In ticket [ZD 48343](https://discuss.zendesk.com/agent/tickets/48343) we got a report from a customer that they weren't able to follow the instructions to [restore PCF](http://docs.pivotal.io/pivotalcf/1-9/customizing/backup-restore/restore-pcf.html) because `enforce_storage_engine` is now set to InnoDB, and a user cannot restore the mysql.db table, which is MyISAM.