### PR TITLE
updated AWS doc information.

### DIFF
--- a/cloudform-er-config.html.md.erb
+++ b/cloudform-er-config.html.md.erb
@@ -220,7 +220,7 @@ Runtime file storage, select the **External S3-Compatible Filestore** option and
 		      <br />
 		      For example, in the **us-west-2** region, use
 		      `https://s3-us-west-2.amazonaws.com/`.
-    * For **S3 Signature Version** and **Region**, keep the default **V2 Signature** values unless your S3 filestore is in Germany or China. These regions require a **V4 Signature**.
+    * For **S3 Signature Version** and **Region**, use the **V4 Signature** values. AWS recommends using [Signature Version 4](http://docs.aws.amazon.com/general/latest/gr/signing_aws_api_requests.html#signature-versions).
     * Select **Server-side Encryption (available for AWS S3 only)** to encrypt the contents of your S3 filestore. See the [AWS S3 documentation](http://docs.aws.amazon.com/AmazonS3/latest/dev/UsingServerSideEncryption.html) for more information.
     * Use the values in your AWS [Outputs tab](#open-outputs) to complete the remaining fields as follows:
     <table border="1" class="nice" >
@@ -253,6 +253,8 @@ Runtime file storage, select the **External S3-Compatible Filestore** option and
         <td>PcfIamUserSecretAccessKey</td>
       </tr>
     </table>
+
+    <p class="note"><strong>Note</strong>: For more information regarding AWS S3 Signatures, please see the <a href="http://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-authenticating-requests.html">Authenticating Requests</a> documentation for additional information.</p>
 
 1. Click **Save**.
 


### PR DESCRIPTION
AWS recommends using Sigv4 whenever possible and uses Sigv4 internally.

Signed-off-by: Mike Lloyd <mlloyd@pivotal.io>