### PR TITLE
Add DIRECTOR-IP-ADDRESS to bosh target cmd

### DIFF
--- a/trouble-advanced.html.md.erb
+++ b/trouble-advanced.html.md.erb
@@ -117,7 +117,7 @@ https://{OPSMANAGER}/api/v0/deployed/director/credentials/director_credentials
 1. Log in using the BOSH Director credentials:
 
     <pre class='terminal'>
-    $ bosh --ca-cert /var/tempest/workspaces/default/root_ca_certificate target 192.0.2.6
+    $ bosh --ca-cert /var/tempest/workspaces/default/root_ca_certificate target DIRECTOR-IP-ADDRESS
     Target set to 'DIRECTOR_UUID'
     Your username: director
     Enter password: (DIRECTOR_CREDENTIAL)


### PR DESCRIPTION
As pointed out in #113, there's a confusing static IP address in the documentation.  I changed this to be more generic.

No worries if you don't want this PR.

Thanks!