### PR TITLE
Update backup-prepare node count note

### DIFF
--- a/_mysql_proxy_config.html.md.erb
+++ b/_mysql_proxy_config.html.md.erb
@@ -34,7 +34,7 @@
 		* For **Destination directory**, enter the directory on the SCP host where you want to save backup files.
 		* For **Cron Schedule**, enter a valid [cron](https://godoc.org/github.com/robfig/cron) expression to schedule your automated backups. Cron uses your computer's local time zone.
 		* Enable **Backup All Nodes** to make unique backups from each instance of the MySQL server rather than just the first MySQL server instance.
-<p class="note"><strong>Note</strong>: If you choose to enable automated MySQL backups, set the number of instances for the **Backup Prepare Node** under the **Resource Config** section of the Elastic Runtime tile to `0`.</p>
+<p class="note"><strong>Note</strong>: If you choose to enable automated MySQL backups, set the number of instances for the **Backup Prepare Node** under the **Resource Config** section of the Elastic Runtime tile to `1`.</p>
 
 1. If you want to log audit events for internal MySQL, select **Enable server activity logging** under **Server Activity Logging**.
 	1. For the **Event types** field, you can enter the events you want the MySQL service to log. By default, this field includes `connect` and `query`, which tracks who connects to the system and what queries are processed. For more information, see the [Logging Events](https://mariadb.com/kb/en/mariadb/about-the-mariadb-audit-plugin/#logging-events) section of the MariaDB documentation.

--- a/_mysql_proxy_config_gcp.html.md.erb
+++ b/_mysql_proxy_config_gcp.html.md.erb
@@ -38,7 +38,7 @@
 		* For **Destination directory**, enter the directory on the SCP host where you want to save backup files.
 		* For **Cron Schedule**, enter a valid [cron](https://godoc.org/github.com/robfig/cron) expression to schedule your automated backups. Cron uses your computer's local time zone.
 		* Enable **Backup All Nodes** to make unique backups from each instance of the MySQL server rather than just the first MySQL server instance.
-<p class="note"><strong>Note</strong>: If you choose to enable automated MySQL backups, set the number of instances for the **Backup Prepare Node** under the **Resource Config** section of the Elastic Runtime tile to `0`.</p>
+<p class="note"><strong>Note</strong>: If you choose to enable automated MySQL backups, set the number of instances for the **Backup Prepare Node** under the **Resource Config** section of the Elastic Runtime tile to `1`.</p>
 
 1. If you want to log audit events for internal MySQL, select **Enable server activity logging** under **Server Activity Logging**.
 	1. For the **Event types** field, you can enter the events you want the MySQL service to log. By default, this field includes `connect` and `query`, which tracks who connects to the system and what queries are processed. For more information, see the [Logging Events](https://mariadb.com/kb/en/mariadb/about-the-mariadb-audit-plugin/#logging-events) section of the MariaDB documentation.


### PR DESCRIPTION
The docs currently suggest to operators that they should set the instance count for the backup-prepare node to `0` when they want to enable backup of their MySQL DB. If they do this, then the backup will not take place because the backup-prepare node is the VM that is going to do that backup.