### PR TITLE
ssh -i takes a private-key

### DIFF
--- a/trouble-advanced.html.md.erb
+++ b/trouble-advanced.html.md.erb
@@ -413,7 +413,7 @@ In most cases, operators should use the `bosh ssh` command in the BOSH CLI to SS
 
 1. Locate the IP address of your BOSH Director and your BOSH Director credentials by following the [steps](#gather) above.
 1. SSH into the BOSH Director with the public key you used with `bosh-init` to deploy the BOSH Director:
-  <pre class="terminal">$ ssh BOSH-DIRECTOR-IP -i PATH-TO-PUBLIC-KEY </pre>
+  <pre class="terminal">$ ssh BOSH-DIRECTOR-IP -i PATH-TO-PRIVATE-KEY </pre>
 1. Enter your BOSH Director credentials to log in.
 
 From the BOSH Director, you can SSH into the other VMs in your deployment by performing the following steps:


### PR DESCRIPTION
`$ man ssh | grep --context=2 "\-i"`

  -i identity_file
             Selects a file from which the identity (private key) for public key authentication is read.