### PR TITLE
Added username for SSH command to ops manager VM

### DIFF
--- a/azure-om-deploy.html.md.erb
+++ b/azure-om-deploy.html.md.erb
@@ -329,7 +329,7 @@ The default OS disk size is too small for deploying PCF. Perform the following s
     <pre class="terminal">$ azure vm start --resource-group $RESOURCE\_GROUP --name ops-manager</pre>
 
 1. SSH into the Ops Manager VM, replacing `YOUR-OPS-MAN-IP` with the public IP address of Ops Manager that you recorded in a previous step:
-    <pre class="terminal">$ ssh -i opsman YOUR-OPS-MAN-IP</pre>
+    <pre class="terminal">$ ssh -i opsman ubuntu@YOUR-OPS-MAN-IP</pre>
     If the private key you generated is not `opsman`, provide the correct filename instead.
 
 1. From the Ops Manager VM, use `df` to confirm that the OS disk has been resized:


### PR DESCRIPTION
The SSH command fails in its current state with `Permission denied (publickey)`

This is because we didn't specify the ubuntu username.

This PR corrects the command.