### PR TITLE
Issue #126 - opsmanager and stemcell container definition updated

### DIFF
--- a/azure-arm-template.html.md.erb
+++ b/azure-arm-template.html.md.erb
@@ -172,17 +172,13 @@ Azure for PCF uses multiple general-purpose Azure storage accounts. The BOSH and
         1. From the `data:` field in the output above, record the full value of `connectionstring` from the output above, starting with and including `DefaultEndpointsProtocol=`.
         1. Export the connection string, choosing a unique name for `CONNECTION_STRING_N`. For example, `CONNECTION_STRING_2`.
         <pre class="terminal">$ export CONNECTION\_STRING\_N="YOUR-CONNECTION-STRING"</pre> 
-        1. Create a container for Ops Manager:
-        <pre class="terminal">$ azure storage container create opsmanager \
-        --connection-string $CONNECTION\_STRING\_N</pre>
         1. Create a container for BOSH:
         <pre class="terminal">$ azure storage container create bosh \
         --connection-string $CONNECTION\_STRING\_N</pre>
         1. Create a container for the stemcell:
-        <pre class="terminal">$ azure storage container create stemcell --permission blob \
+        <pre class="terminal">$ azure storage container create stemcell \
         --connection-string $CONNECTION\_STRING\_N</pre>
         </pre>
-        <p class="note"><strong>Note</strong>: Make sure the stemcell container is assigned `blob` permissions.</p>
 
 1. Create a network security group named `pcf-nsg`.
 <pre class="terminal">


### PR DESCRIPTION
Issue #126:

`opsmanager` container is not needed for deployment storage accounts.
`stemcell` container should not be "public blob" if planning to use PLRS (recommended).

