### PR TITLE
Edits to BBR backup and restore

### DIFF
--- a/backup-restore/_bosh_target_director.html.md.erb
+++ b/backup-restore/_bosh_target_director.html.md.erb
@@ -1,17 +1,16 @@
 
-1. Install Ruby and the [BOSH CLI Ruby gem](http://docs.cloudfoundry.org/bosh/bosh-cli.html) on a machine outside of your PCF deployment.
+1. Install the [BOSH v2 CLI](https://bosh.io/docs/cli-v2.html#install) on a machine outside of your PCF deployment.
 
 1. From the Installation Dashboard in Ops Manager, select **Ops Manager Director > Status** and record the IP address listed for the Director.
 You access the BOSH Director using this IP address.
   <img src="../images/director-ip.png">
 1. Click **Credentials** and record the Director credentials.
   <img src="../images/director-creds.png">
-1. From the command line, run `bosh target` to log into the BOSH Director using the IP address and credentials that you recorded:
+1. From the command line, run `bosh-cli log-in` to log into the BOSH Director using the IP address and credentials that you recorded:
   <pre class='terminal'>
-  $ bosh target 192.0.2.3
-  Target set to 'bosh-1234abcd1234abcd1234'
-  Your username: director
-  Enter password: ********************
-  Logged in as 'director'
+  $ bosh-cli -e 192.0.2.3 --ca-cert /var/tempest/workspaces/default/root\_ca\_certificate log-in
+  Email (): director
+  Password (): *******************
+  Successfully authenticated with UAA
+  Succeeded
   </pre>
-  <p class="note"><strong>Note</strong>: If <code>bosh target</code> does not prompt you for your username and password, run <code>bosh login</code>.</p>

--- a/backup-restore/backup-pcf-bbr.html.md.erb
+++ b/backup-restore/backup-pcf-bbr.html.md.erb
@@ -25,20 +25,22 @@ BBR is a binary that can back up and restore BOSH deployments and BOSH Directors
 
 BBR backs up the following PCF components:
 
-* **Elastic Runtime**: Elastic Runtime must be configured with an internal MySQL database and a WebDAV/NFS blobstore to be backed up and restored with BBR. 
+* **Elastic Runtime**: Elastic Runtime must be configured with an internal MySQL database and a WebDAV/NFS blobstore to be backed up and restored with BBR.
 * **BOSH Director**: The BOSH Director must have an internal Postgres database to be backed up and restored with BBR.
 
 Service tiles have different [levels of integration](http://docs.pivotal.io/tiledev/stages.html). BBR may or may not be able to back up your service tiles depending on their level of integration. Consult the following list:
 
 * Service brokers: You can back up and restore all brokered services with the procedures documented in this topic and in the [Restoring Pivotal Cloud Foundry from Backup with BBR](restore-pcf-bbr.html) topic. Because a brokered service runs external to PCF, BBR backs up and restores the VMs and the service instances, but not the service data.
 * Managed services: Because managed services are BOSH releases, they must implement the BBR scripts. Otherwise, you cannot use BBR to back up and restore them. If the managed service has implemented BBR scripts, BBR backs up and restores both the VMs and the service data.
-* On-demand services: You must perform additional steps to back up and restore on-demand services with BBR. **Question: What are those additional steps?**
+* On-demand services: On-demand instances will be redeployed, but at present the data in the instance is not backed up. A new, empty instance of the on-demand service will be restored.
 
 ## <a id='workflow'></a>Workflow
 
 Operators download the BBR binary and transfer it to a jumpbox. Then they run BBR from the jumpbox, specifying the name of the BOSH deployment to back up.
 
-BBR examines the jobs in the BOSH deployment, and triggers the backup script for each release in the prescribed order. The backup artifacts are drained to the jumpbox, where the operator can transfer them to storage and use them to [restore](restore-pcf.html) PCF.
+BBR examines the jobs in the BOSH deployment, and triggers the scripts in stages -- first pre-backup lock, then backup, then post-backup unlock. Scripts in the same stage are all triggered together -- e.g. all pre-backup lock scripts are triggered before any backup scripts. Scripts within a stage may be triggered in any order.
+
+The backup artifacts are drained to the jumpbox, where the operator can transfer them to storage and use them to [restore](restore-pcf.html) PCF.
 
 The following diagram shows a sample backup flow.
 
@@ -48,7 +50,7 @@ The following diagram shows a sample backup flow.
 
 Perform the following steps to record the Cloud Controller Database encryption credentials:
 
-1. Navigate to `YOUR-OPS-MAN-FQDN` in a browser and log in to the Ops Manager Installation Dashboard. 
+1. Navigate to Ops Manager in a browser and log in to the Ops Manager Installation Dashboard.
 1. Select **Pivotal Elastic Runtime > Credentials** and locate the Cloud Controller section.
 1. Record the Cloud Controller **DB Encryption Credentials**.
 You must provide these credentials if you contact [Pivotal Support](https://support.pivotal.io) for help
@@ -61,8 +63,8 @@ restoring your installation.
 Perform the following steps to enable the backup preparer node:
 
 1. In the Elastic Runtime tile, click **Internal MySQL**.
-1. Under **Automated Backups Configuration**, select **Enable automated backups from MySQL to an S3 bucket or other S3-compatible file store**. Fill in the required fields with any text value, and set the **Cron Schedule** to a cron-formatted date that doesn't exist. For example, use February 31: `0 0 12 31 2 ? *`. 
-	<p class="note"><strong>Note</strong>: If you do not select this option, the backup will run successfully, but the subsequent restore will fail.</p>
+1. Under **Automated Backups Configuration**, select **Enable automated backups from MySQL to an S3 bucket or other S3-compatible file store**. Fill in the required fields with any text value, and set the **Cron Schedule** to a cron-formatted date that doesn't exist. For example, use February 31: `0 0 12 31 2 ? *`.
+	<p class="note"><strong>Note</strong>: If you do not select this option, the backup will fail.</p>
 1. Click **Resource Config** and use the dropdown menu to scale up the **Backup Prepare Node** to one instance.
 	<%= image_tag("backup-prepare-node.png") %>
 1. Navigate back to the Ops Manager Installation Dashboard and click **Apply Changes** to redeploy.
@@ -93,18 +95,21 @@ Perform the following steps to retrieve the IP address of your BOSH Director and
 
 ## <a id='identify-deployment'></a> Step 5: Identify Your Deployment
 
-After logging in to your BOSH Director, run `bosh deployments` to identify the name of the BOSH deployment that contains PCF. 
+After logging in to your BOSH Director, run the following command to identify the name of the BOSH deployment that contains PCF:
+
+`$ bosh-cli -e <DIRECTOR_IP> --ca-cert /var/tempest/workspaces/default/root_ca_certificate deployments`
 
 The following example displays information for a BOSH deployment named `cf-example`:
 
 <pre class='terminal'>
-$ bosh deployments
-+-------------+--------------+-------------------------------------------------+
-| Name        | Release(s)   | Stemcell(s)                                     |
-+-------------+--------------+-------------------------------------------------+
-| cf-example  | cf-mysql/10  | bosh-vsphere-esxi-ubuntu-trusty-go_agent/2690.3 |
-|             | cf/183.2     |                                                 |
-+-------------+--------------+-------------------------------------------------+
+Name                     Release(s)
+cf-a3a6ae6c15a2774fba54  push-apps-manager-release/661.1.24
+                         cf-backup-and-restore/0.0.1
+                         binary-buildpack/1.0.11
+                         capi/1.28.0
+                         cf-autoscaling/91
+                         cf-mysql/35
+                         ...
 </pre>
 
 ## <a id='jumpbox'></a>Step 6: Set Up Your Jumpbox
@@ -149,7 +154,7 @@ Perform the following steps to transfer BBR to your jumpbox:
 	<pre class="terminal">$ chmod a+x bbr</pre>
 1. SCP the binary to your jumpbox:
 	<pre class="terminal">$ scp LOCAL\_PATH\_TO\_BBR/bbr JUMPBOX\_USER/JUMPBOX\_ADDRESS</pre>
-	If your jumpbox has access to the internet, you can also SSH into your jumpbox and use `wget`: 
+	If your jumpbox has access to the internet, you can also SSH into your jumpbox and use `wget`:
 	<pre class="terminal">
 	$ ssh JUMPBOX\_USER/JUMPBOX\_ADDRESS -i YOUR\_CERTIFICATE.pem
 	$ wget BBR\_RELEASE\_URL
@@ -175,39 +180,39 @@ Perform the following steps to check that your BOSH Director is reachable and ha
     pre-backup-check</pre>
 
     Replace the placeholder values as follows:
-    * `BOSH_CLIENT`, `BOSH_CLIENT_SECRET`: ** Use the BOSH UAA user provided in  **Pivotal Ops Manager > Credentials > Uaa Bbr Client Credentials** 
+    * `BOSH_CLIENT`, `BOSH_CLIENT_SECRET`: ** Use the BOSH UAA user provided in  **Pivotal Ops Manager > Credentials > Uaa Bbr Client Credentials**
     * `BOSH_DIRECTOR_IP`: You retrieved this value in the [Step 3: Retrieve BOSH Director Address and Credentials](#retrieve) section.
     * `DEPLOYMENT-NAME`: You retrieved this value in the [Step 4: Identify Your Deployment](#identify-deployment) section.
     * `PATH_TO_BOSH_SERVER_CERT`: This is the path to the BOSH Director’s Certificate Authority (CA) certificate, if the certificate is not verifiable by the local machine’s certificate chain.
 
-1. If the pre-backup check succeeds, continue to the [next section](#bbr-backup). If it fails, the deployment you selected may not have the correct backup scripts, or the connection to the BOSH Director may have failed. 
+1. If the pre-backup check succeeds, continue to the [next section](#bbr-backup). If it fails, the deployment you selected may not have the correct backup scripts, or the connection to the BOSH Director may have failed.
 	<br><br>
 	The following error occurs if you have not enabled the Elastic Runtime MySQL Backup Prepare Node:
 
 		1 error occurred:
 
 		* The mysql restore script expects a backup script which produces mysql-artifact artifact which is not present in the deployment.
-	Follow the instructions in the [Step 2: Enable Backup Preparer Node](#backup-preparer-node) section and retry. 
+	Follow the instructions in the [Step 2: Enable Backup Preparer Node](#backup-preparer-node) section and retry.
 
 ## <a id='bbr-backup'></a> Step 9: Back Up Your Elastic Runtime Deployment
 
 Run the BBR backup command from your jumpbox to back up your Elastic Runtime deployment:
 <pre class="terminal">
 $ BOSH\_CLIENT\_SECRET=BOSH\_CLIENT\_SECRET \
-	bbr deployment
+	nohup bbr deployment
 	--target BOSH\_DIRECTOR\_IP \
 	--username BOSH\_CLIENT \
 	--deployment DEPLOYMENT\_NAME \
 	--ca-cert PATH\_TO\_BOSH\_SERVER\_CERT \
 	backup</pre>
 
-Use the optional `--debug` flag to enable debug logs. See the [Logging](#logging) section for more information.	
+Use the optional `--debug` flag to enable debug logs. See the [Logging](#logging) section for more information.
 <p class="note"><strong>Note</strong>: The BBR backup command can take a long time to complete. Pivotal recommends you run it independently of the SSH session, so that the process can continue running even if your connection to the jumpbox fails. The command above uses `nohup` but you could also run the command in a `screen` or `tmux` session.</p>
-BBR stores each backup in the current working directory, in a directory of the same name as the deployment. As a result, you cannot run multiple backups of a deployment from the same working directory without first moving or renaming the existing backup. 
+BBR stores each backup in the current working directory, in a directory of the same name as the deployment. As a result, you cannot run multiple backups of a deployment from the same working directory without first moving or renaming the existing backup.
 
 If the commands completes successfully, do the following:
 
-1. Move the backup artifact off the jumpbox to your preferred storage space. The backup created by BBR consists of a folder with the backup artifacts and metadata files. However, Pivotal recommends compressing and encrypting the files. 
+1. Move the backup artifact off the jumpbox to your preferred storage space. The backup created by BBR consists of a folder with the backup artifacts and metadata files. However, Pivotal recommends compressing and encrypting the files.
 1. Make redundant copies of your backup and store them in multiple locations in order to minimize the risk of losing your backups in the event of a disaster.
 1. Attempt a test restore on every backup in order to validate it by performing the procedures in the [Step 10: Validate Your Backup](#validate-backup) section below.
 
@@ -216,7 +221,7 @@ If the command fails, do the following:
 1. Ensure all the parameters in the command are set.
 1. Ensure the BOSH Director credentials are valid.
 1. Ensure the specified deployment exists.
-1. Consult the [Exit Codes](#exit-codes) section below. 
+1. Consult the [Exit Codes](#exit-codes) section below.
 
 ## <a id='bbr-backup-director'></a> Step 10: Back Up Your BOSH Director
 
@@ -243,11 +248,11 @@ Perform the following steps to back up your BOSH Director:
 	* `PATH_TO_PRIVATE_KEY`: This is the path to the private key file you created above.
 	* `HOST`: This is the address of the BOSH Director. If the BOSH Director is public, this is a URL, for example `https://my-bosh.xxx.cf-app.com`. Otherwise, this is the `BOSH_DIRECTOR_IP`, which you retrieved in the [Step 3: Retrieve BOSH Director Address and Credentials](#retrieve) section.
 
-Included in the BOSH Director backup are the BOSH UAA database and the CredHub database. 
+Included in the BOSH Director backup are the BOSH UAA database and the CredHub database.
 
 ## <a id='validate-backup'></a> Step 11: (Optional) Validate Your Backup
 
-After backing up PCF, you may want to validate your backup by restoring it to a similar environment and checking the applications. Because BBR is designed for disaster recovery, its backups are intended to be restored to an environment deployed with the same configuration. 
+After backing up PCF, you may want to validate your backup by restoring it to a similar environment and checking the applications. Because BBR is designed for disaster recovery, its backups are intended to be restored to an environment deployed with the same configuration.
 
 Perform the following steps to spin up a second environment that matches the original in order to test a restore:
 
@@ -280,7 +285,7 @@ Perform the following steps to spin up a second environment that matches the ori
 
 1. Click the **Ops Manager Director** tile.
 1. Click **Create Networks** and update the networks as appropriate.
-1. SSH into your Ops Manager VM. For more information, see the [SSH into Ops Manager](../trouble-advanced.html#ssh) section of the <em>Advanced Troubleshooting with the BOSH CLI</em> topic. 
+1. SSH into your Ops Manager VM. For more information, see the [SSH into Ops Manager](../trouble-advanced.html#ssh) section of the <em>Advanced Troubleshooting with the BOSH CLI</em> topic.
 1. On the Ops Manager VM, delete the `/var/tempest/workspaces/default/deployments/bosh-state.json` file.
 1. Navigate to the Ops Manager Installation Dashboard and click **Apply Changes** to deploy a new BOSH Director and a new Elastic Runtime.
 1. Ensure your new environment has the same following credentials as the original environment:
@@ -292,7 +297,7 @@ Perform the following steps to spin up a second environment that matches the ori
 		* `cc.db_encryption_key` consumed by `cloud_controller_clock`, `cloud_controller_worker`, `cloud_controller_ng` jobs
 		* `diego.bbs.encryption_keys.passphrase` consumed by `bbs` job
 
-	**Question: Doesn't the new environment have the same credentials as the old one just by virtue of importing the Ops Manager installation?** 
+	**Question: Doesn't the new environment have the same credentials as the old one just by virtue of importing the Ops Manager installation?**
 
 1. Run the BBR restore command from your jumpbox to restore your Elastic Runtime deployment:
 <pre class="terminal">
@@ -319,10 +324,10 @@ After the restore is completed, perform the following steps to check the status 
 	* To see the list of spaces for your targeted org, run `cf spaces`.
 	* Target each space in turn with `cf target -s YOUR-SPACE`.
 	* To see the list of routes and their domains for your targeted space, run `cf routes`.
-	* To see the list of apps for your targeted space, run `cf apps`. Check that the apps which should be running can start successfully. 
+	* To see the list of apps for your targeted space, run `cf apps`. Check that the apps which should be running can start successfully.
 	* Ensure that your apps are still bound to the expected services with `cf services`. Backing up PCF with BBR doesn't back up service data.
 	<br><br>
-	Under normal circumstances, the existing domain will not be pointed to your restored PCF deployment. Therefore, if you want to make HTTP requests to the restored applications, you must use the IP address of the restored Router. However, the restored PCF deployment remains linked to the original domain. As a result, you must set the original domain in the `Host` header in order to route HTTP requests to the restored applications. 
+	Under normal circumstances, the existing domain will not be pointed to your restored PCF deployment. Therefore, if you want to make HTTP requests to the restored applications, you must use the IP address of the restored Router. However, the restored PCF deployment remains linked to the original domain. As a result, you must set the original domain in the `Host` header in order to route HTTP requests to the restored applications.
 	<br><br>
 	You can use `curl` to set the original domain in the header. In the following example command, the Router IP address is `10.0.1.16` and the app domain is `cf-original-app.com`:
 
@@ -368,7 +373,7 @@ The exit code returned by BBR indicates the status of the backup. The following 
 
 If multiple failures occur, your exit code reflects a combination of values. Use bitwise AND to determine which failures occurred.
 
-For example, the exit code `5` indicates that the pre-backup lock failed and a general error occurred. 
+For example, the exit code `5` indicates that the pre-backup lock failed and a general error occurred.
 
 To check that a bit is set, use bitwise AND, as demonstrated by the following example of exit code `20`:
 
@@ -379,7 +384,7 @@ To check that a bit is set, use bitwise AND, as demonstrated by the following ex
 </code>
 </pre>
 
-Exit code `20` indicates that the pre-backup lock failed and cleanup failed. 
+Exit code `20` indicates that the pre-backup lock failed and cleanup failed.
 
 ### <a id='logging'></a>Logging
 

--- a/backup-restore/restore-pcf-bbr.html.md.erb
+++ b/backup-restore/restore-pcf-bbr.html.md.erb
@@ -186,6 +186,13 @@ $ BOSH\_CLIENT\_SECRET=BOSH_PASSWORD \
     * `DEPLOYMENT-NAME`: You retrieved this value in the [Step 4: Identify Your Deployment](#identify-deployment) section.
     * `PATH_TO_BOSH_SERVER_CERT`: This is the path to the BOSH Director’s Certificate Authority (CA) certificate, if the certificate is not verifiable by the local machine’s certificate chain.
 
+1. If you have container-to-container networking enabled in the Elastic Runtime, you will need to perform an additional cleanup step after restoring ERT.
+  * Get the MySQL admin password from **Pivotal Ops Manager > Pivotal Elastic Runtime > Credentials > Mysql Admin Credentials**
+  * SSH onto the `mysql` VM.
+  * Run `sudo /var/vcap/packages/mariadb/bin/mysql -u root -p` and enter the admin password.
+  * At the MySQL prompt, enter `use silk; drop table subnets; drop table gorp_migrations;`.
+  * SSH onto each `diego_database` VM and run `sudo monit restart silk-controller`.
+
 1. If desired, scale the MySQL Server job back up to its previous number of instances by going to the Ops Manager Installation Dashboard and navigating to **Pivotal Elastic Runtime > Resource Config** and clicking **Apply Changes** to deploy.
 
 

--- a/backup-restore/restore-pcf-bbr.html.md.erb
+++ b/backup-restore/restore-pcf-bbr.html.md.erb
@@ -34,7 +34,7 @@ Prepare your environment for PCF by following the instructions specific to your 
 1. Perform the procedures for your IaaS to deploy Ops Manager:
   * [Launching an Ops Manager Director Instance on AWS](../cloudform-om-deploy.html)
   * [Launching an Ops Manager Director Instance on Azure](../azure-arm-template.html)
-  *  [Launching an Ops Manager Director Instance on GCP](../gcp-om-deploy.html)
+  * [Launching an Ops Manager Director Instance on GCP](../gcp-om-deploy.html)
   * [Provisioning the OpenStack Infrastructure](../openstack-setup.html)
   * [Deploying Operations Manager to vSphere](../deploying-vm.html)
 
@@ -62,17 +62,24 @@ Prepare your environment for PCF by following the instructions specific to your 
 
 ## <a id="bosh-state"></a> Step 3: Remove BOSH State File
 
-1. SSH into your Ops Manager VM. For more information, see the [SSH into Ops Manager](../trouble-advanced.html#ssh) section of the <em>Advanced Troubleshooting with the BOSH CLI</em> topic. 
+1. SSH into your Ops Manager VM. For more information, see the [SSH into Ops Manager](../trouble-advanced.html#ssh) section of the <em>Advanced Troubleshooting with the BOSH CLI</em> topic.
 1. On the Ops Manager VM, delete the `/var/tempest/workspaces/default/deployments/bosh-state.json` file.
-1. Navigate to Ops Manager Installation Dashboard and click **Apply Changes** to redeploy. ***TBD Director only Apply changes***.
+1. Log into Ops Manager. For each tile that requires one, upload the required stemcell.
+<p class="note"><strong>Note</strong>: Do not click 'Apply Changes' at this time.</p>
 
-## <a id="director-only"></a> Step 4: Apply changes to install only the BOSH Director 
-POST "https://example.com/api/v0/installations" \ 
-    -d '{
-"deploy_products": none,
-"errands": {},
-  "ignore_warnings": true
-}'
+## <a id="director-only"></a> Step 4: Apply changes to deploy only the BOSH Director
+
+1. SSH into your jumpbox.
+1. [Download](https://github.com/pivotal-cf/om/releases/latest) the latest version of `om-linux`, by running e.g. `wget https://github.com/pivotal-cf/om/releases/download/0.23.0/om-linux`.
+1. Make the downloaded binary executable by running e.g. `chmod +x om-linux`.
+1. Run the following `om` command:
+  <pre class='terminal'>
+  $ om-linux -t OPS\_MANAGER\_URL -u OPS\_MANAGER\_ADMIN\_USER \
+  -p OPS\_MANAGER\_ADMIN\_PASSWORD \
+  -k curl -p /api/v0/installations -x POST -d \
+  '{"deploy\_products": "none", "errands": {}, "ignore\_warnings": true }'
+  </pre>
+1. The director deploy will begin. Follow its progress in the Ops Manager UI.
 
 ## <a id="artifacts-jumpbox"></a> Step 5: Transfer Artifacts to Jumpbox
 
@@ -89,36 +96,38 @@ Perform the following steps to retrieve the IP address of your BOSH Director and
 
 ## <a id='identify-deployment'></a> Step 7: Identify Your Deployment
 
-After logging in to your BOSH Director, run `bosh deployments` to identify the name of the BOSH deployment that contains PCF. 
+After logging in to your BOSH Director, run `bosh deployments` to identify the name of the BOSH deployment that contains PCF.
 
 The following example displays information for a BOSH deployment named `cf-example`:
 
 <pre class='terminal'>
-$ bosh deployments
-+-------------+--------------+-------------------------------------------------+
-| Name        | Release(s)   | Stemcell(s)                                     |
-+-------------+--------------+-------------------------------------------------+
-| cf-example  | cf-mysql/10  | bosh-vsphere-esxi-ubuntu-trusty-go_agent/2690.3 |
-|             | cf/183.2     |                                                 |
-+-------------+--------------+-------------------------------------------------+
+$ bosh-cli -e [environment] -d [deployment-name] deployments
+Name                     Release(s)
+cf-example               push-apps-manager-release/661.1.24
+                         cf-backup-and-restore/0.0.1
+                         binary-buildpack/1.0.11
+                         capi/1.28.0
+                         cf-autoscaling/91
+                         cf-mysql/35
+                         ...
 </pre>
 
 ## <a id='restore-bosh'></a> Step 8: Restore the BOSH Director
 
-1. SSH into your jumpbox:
-  <pre class="terminal">
-  $ ssh JUMPBOX\_USER/JUMPBOX\_ADDRESS -i YOUR\_CERTIFICATE.pem
+1. SSH into your jumpbox.
+1. Using the same `om` binary as in [Step 4: Apply changes to deploy only the BOSH Director](#director-only), run:
+  <pre class='terminal'>
+  $ om-linux -t OPS\_MANAGER\_URL -u OPS\_MANAGER\_ADMIN\_USER \
+  -p OPS\_MANAGER\_ADMIN\_PASSWORD \
+  -k curl -p /api/v0/deployed/director/credentials/bbr\_ssh\_credentials
   </pre>
-1. Navigate to the Ops Manager Installation Dashboard.
-1. Click the Elastic Runtime tile.
-1. Click the **Credentials** tab.
-1. Locate **Bbr Ssh Credentials** and click **Link to Credential** next to it.
-1. Copy the value for `private_key_pem`, beginning with "-----BEGIN RSA PRIVATE KEY-----" and paste it into a file that you save on your jumpbox.
-1. Ensure the BOSH Director backup artifact is in the folder you will run BBR from. 
+1. Copy the value for `private_key_pem`, beginning with `-----BEGIN RSA PRIVATE KEY-----` to your clipboard.
+1. Run `printf -- "[pasted_private_key]" > PRIVATE_KEY`. This will reformat the key and save it to a file called `PRIVATE_KEY` in the current directory.
+1. Ensure the BOSH Director backup artifact is in the folder you will run BBR from.
 1. Run the BBR restore command from your jumpbox to restore the BOSH Director:
   <pre class="terminal">
-  $ bbr director \
-    --private-key-path PATH\_TO\_PRIVATE\_KEY \
+  $ nohup bbr director \
+    --private-key-path PRIVATE\_KEY \
     --username bbr
     --host HOST \
     restore
@@ -126,12 +135,12 @@ $ bosh deployments
   Use the optional `--debug` flag to enable debug logs. See the [Logging](backup-pcf-bbr.html#logging) section of the <em>Backing Up Pivotal Cloud Foundry with BBR</em> topic for more information.
   <br><br>
   Replace the placeholder values as follows:
-  * `PATH_TO_PRIVATE_KEY`: This is the path to the private key file you created above. 
+  * `PATH_TO_PRIVATE_KEY`: This is the path to the private key file you created above.
   * `HOST`: This is the address of the BOSH Director. If the BOSH Director is public, this will be a URL, e.g. https://my-bosh.xxx.cf-app.com. Otherwise, it will be the `BOSH_DIRECTOR_IP`, which you retrieved in the [Step 3: Retrieve BOSH Director Address and Credentials](#retrieve) section.
 
 <p class="note"><strong>Note</strong>: The BBR restore command can take a long time to complete. Pivotal recommends you run it independently of the SSH session, so that the process can continue running even if your connection to the jumpbox fails. The command above uses <code>nohup</code> but you could also run the command in a <code>screen</code> or <code>tmux</code> session.</p>
 
-If the commands completes successfully, continue to [Step 9: Remove the cloud ids for all deployments](#bosh-cck).
+If the commands completes successfully, continue to [Step 9: Remove stale cloud IDs for all deployments](#bosh-cck).
 
 If the command fails, do the following:
 
@@ -141,22 +150,27 @@ If the command fails, do the following:
 1. Ensure the source deployment is incompatible with the target deployment.
 1. Ensure that the jumpbox can reach the BOSH Director.
 
-## <a id="bosh-cck"></a> Step 9: Remove the cloud ids for all deployments
-For every deployment in the BOSH Director, run this command `bosh-cli -e [environment] -d [deployment-name] -n cck --resolution delete_disk_reference --resolution delete_vm_reference`
-You can use the list of deployments returned in [Step 7: Identify Your Deployment](#identify-deployment)
+## <a id="bosh-cck"></a> Step 9: Remove stale cloud IDs for all deployments
+For **every deployment** in the BOSH Director, run this command:
+<pre class="terminal">
+$ bosh-cli -e [environment] -d [deployment-name] -n cck \
+--resolution delete\_disk\_reference \
+--resolution delete\_vm\_reference
+</pre>
+This will reconcile the BOSH Director's internal state with the state in the IaaS. You can use the list of deployments returned in [Step 7: Identify Your Deployment](#identify-deployment).
 
 ## <a id='restore-ert'></a> Step 10: Apply Changes
-1. Navigate to Ops Manager Installation Dashboard and click **Apply Changes** to redeploy.  ***TBD Director only Apply changes***
+Navigate to Ops Manager Installation Dashboard and click **Apply Changes** to redeploy.
 
 ## <a id='restore-ert'></a> Step 11: Restore Elastic Runtime
 
 1. Navigate to the Ops Manager Installation Dashboard and click **Apply Changes**. This deploys Elastic Runtime.
 
-1. If the Elastic Runtime backup artifact has been moved from the jumpbox, put it back into the directory bbr is run from. 
+1. If the Elastic Runtime backup artifact has been moved from the jumpbox, put it back into the directory bbr is run from.
 
 1. Run the BBR restore command from your jumpbox to restore Elastic Runtime:
 <pre class="terminal">
-$  BOSH\_CLIENT\_SECRET=BOSH_PASSWORD \
+$ BOSH\_CLIENT\_SECRET=BOSH_PASSWORD \
   bbr deployment
   --target BOSH\_DIRECTOR\_IP \
   --username BOSH\_CLIENT \
@@ -165,8 +179,7 @@ $  BOSH\_CLIENT\_SECRET=BOSH_PASSWORD \
   restore </pre>
 
     Replace the placeholder values as follows:
-    * `BOSH_CLIENT`, `BOSH_CLIENT_SECRET`: ** Use the BOSH UAA user provided in  **Pivotal Ops Manager > Credentials > Uaa Bbr Client Credentials** 
+    * `BOSH_CLIENT`, `BOSH_CLIENT_SECRET`: Use the BOSH UAA user provided in  **Pivotal Ops Manager > Credentials > Uaa Bbr Client Credentials**.
     * `BOSH_DIRECTOR_IP`: You retrieved this value in the [Step 3: Retrieve BOSH Director Address and Credentials](#retrieve) section.
     * `DEPLOYMENT-NAME`: You retrieved this value in the [Step 4: Identify Your Deployment](#identify-deployment) section.
     * `PATH_TO_BOSH_SERVER_CERT`: This is the path to the BOSH Director’s Certificate Authority (CA) certificate, if the certificate is not verifiable by the local machine’s certificate chain.
-

--- a/backup-restore/restore-pcf-bbr.html.md.erb
+++ b/backup-restore/restore-pcf-bbr.html.md.erb
@@ -161,12 +161,12 @@ This will reconcile the BOSH Director's internal state with the state in the Iaa
 
 <p class="note"><strong>Note</strong>: If the <code>bosh-cli cck</code> command does not successfully delete disk references, e.g. if you see <code>Scanning 19 persistent disks: 19 OK, 0 missing ...</code>, please follow the additional instructions in <a href="#removing-disks">Appendix: Removing Unused Disks</a>.</p>
 
-## <a id='restore-ert'></a> Step 10: Apply Changes
-Navigate to Ops Manager Installation Dashboard and click **Apply Changes** to redeploy.
+## <a id='redeploy-ert'></a> Step 10: Redeploy ERT
+1. From the Ops Manager Installation Dashboard, navigate to **Pivotal Elastic Runtime > Resource Config**.
+1. Ensure the number of instances for MySQL Server is set to 1.
+1. Navigate to Ops Manager Installation Dashboard and click **Apply Changes** to redeploy.
 
 ## <a id='restore-ert'></a> Step 11: Restore Elastic Runtime
-
-1. Navigate to the Ops Manager Installation Dashboard and click **Apply Changes**. This deploys Elastic Runtime.
 
 1. If the Elastic Runtime backup artifact has been moved from the jumpbox, put it back into the directory bbr is run from.
 
@@ -185,6 +185,9 @@ $ BOSH\_CLIENT\_SECRET=BOSH_PASSWORD \
     * `BOSH_DIRECTOR_IP`: You retrieved this value in the [Step 3: Retrieve BOSH Director Address and Credentials](#retrieve) section.
     * `DEPLOYMENT-NAME`: You retrieved this value in the [Step 4: Identify Your Deployment](#identify-deployment) section.
     * `PATH_TO_BOSH_SERVER_CERT`: This is the path to the BOSH Director’s Certificate Authority (CA) certificate, if the certificate is not verifiable by the local machine’s certificate chain.
+
+1. If desired, scale the MySQL Server job back up to its previous number of instances by going to the Ops Manager Installation Dashboard and navigating to **Pivotal Elastic Runtime > Resource Config** and clicking **Apply Changes** to deploy.
+
 
 ## <a id='removing-disks'></a> Appendix: Removing Unused Disks
 

--- a/backup-restore/restore-pcf-bbr.html.md.erb
+++ b/backup-restore/restore-pcf-bbr.html.md.erb
@@ -159,6 +159,8 @@ $ bosh-cli -e [environment] -d [deployment-name] -n cck \
 </pre>
 This will reconcile the BOSH Director's internal state with the state in the IaaS. You can use the list of deployments returned in [Step 7: Identify Your Deployment](#identify-deployment).
 
+<p class="note"><strong>Note</strong>: If the <code>bosh-cli cck</code> command does not successfully delete disk references, e.g. if you see <code>Scanning 19 persistent disks: 19 OK, 0 missing ...</code>, please follow the additional instructions in <a href="#removing-disks">Appendix: Removing Unused Disks</a>.</p>
+
 ## <a id='restore-ert'></a> Step 10: Apply Changes
 Navigate to Ops Manager Installation Dashboard and click **Apply Changes** to redeploy.
 
@@ -183,3 +185,14 @@ $ BOSH\_CLIENT\_SECRET=BOSH_PASSWORD \
     * `BOSH_DIRECTOR_IP`: You retrieved this value in the [Step 3: Retrieve BOSH Director Address and Credentials](#retrieve) section.
     * `DEPLOYMENT-NAME`: You retrieved this value in the [Step 4: Identify Your Deployment](#identify-deployment) section.
     * `PATH_TO_BOSH_SERVER_CERT`: This is the path to the BOSH Director’s Certificate Authority (CA) certificate, if the certificate is not verifiable by the local machine’s certificate chain.
+
+## <a id='removing-disks'></a> Appendix: Removing Unused Disks
+
+If `bosh-cli cck` does not clean up all disk references, there are disks from a previous deployment in the IaaS which will prevent recreated deployments from working.
+
+To clean up these disks, either:
+
+* target the redeployed BOSH Director using the BOSH CLI, list deployments and delete each deployment using `bosh-cli -d DEPLOYMENT_NAME delete-deployment`, or
+* manually log into your IaaS account and delete the disks by hand.
+
+Once the disks are deleted, continue with [Step 9: Remove stale cloud IDs for all deployments](#bosh-cck).


### PR DESCRIPTION
- moved to using v2 BOSH CLI instead of Ruby BOSH 
- add workaround for case where disks still exist on IaaS
- general reformatting
- installing and using `om` to get Ops Manager config
- fix director-only deploy step

Thanks!

Henry and Ed (@edwardecook)