### PR TITLE
fix URL to CloudFormation Template

### DIFF
--- a/cloudform-template.html.md.erb
+++ b/cloudform-template.html.md.erb
@@ -19,13 +19,8 @@ The template is designed to output the resources necessary for two availability 
 
 ## <a id='download-template'></a>Step 1: Download the PCF CloudFormation Template ##
 
-1. Sign in to [Pivotal Network](https://network.pivotal.io/).
-
-1. Select <b>Elastic Runtime</b>. From the <b>Releases</b> drop-down menu, select the release that you wish to install.
-
-1. Download the **PCF CloudFormation for AWS Setup**.
-
-1. Save the file as `pcf.json`.
+1. Go to [pcf.json](https://raw.githubusercontent.com/pivotal-cf/docs-pcf-install/master/pcf.json)
+1. Save the page as `pcf.json`.
 
 ## <a id='upload-cert'></a>Step 2: Upload an SSL Certificate to AWS ##
 


### PR DESCRIPTION
CloudFormation Template does not exist on Pivotal Network any more but does on GitHub