### PR TITLE
Fix gem install instructions for uaac

### DIFF
--- a/opsman-users.html.md.erb
+++ b/opsman-users.html.md.erb
@@ -10,7 +10,7 @@ When Ops Manager boots for the first time, you create an admin user. However, yo
 
 <p class="note"><strong>Note:</strong> You can only manage users on the Ops Manager UAA module if you chose to use Internal Authentication instead of an external Identity Provider when configuring Ops Manager.</p>
 
-Follow these steps to add or remove users via the UAAC. If you do not already have the UAAC installed, run `gem install uaac` from a terminal window.
+Follow these steps to add or remove users via the UAAC. If you do not already have the UAAC installed, run `gem install cf-uaac` from a terminal window.
 
 ## <a id='add-user'></a>Adding Users to Ops Manager
 


### PR DESCRIPTION
Not sure if the UAA team used to call their gem `uaac` but it's now `cf-uaac`: https://github.com/cloudfoundry/cf-uaac