### PR TITLE
Add references to the OpsManager API to the BBR pages

### DIFF
--- a/backup-restore/_bosh_target_director_bbr.html.md.erb
+++ b/backup-restore/_bosh_target_director_bbr.html.md.erb
@@ -3,7 +3,13 @@
 
 1. From the Installation Dashboard in Ops Manager, select **Ops Manager Director > Status** and record the IP address listed for the Director.
 You access the BOSH Director using this IP address.
-  <img src="../images/director-ip.png">
+  <img src="../images/director-ip.png"><br />
+  You can also retrieve the director IP address using the Ops Manager API. To do this:
+  * visit the following endpoint: `/api/v0/deployed/products`;
+  * find the product with an `installation_name` starting with `p-bosh-` and copy its `guid`;
+  * visit the following endpoint: `/api/v0/deployed/products/:guid/static_ips` (where `:guid` is the value you've just copied);
+  * you'll find the list of director IPs under the `ips` field.
+  You will need to authenticate to use the API. For more information, see the [Using the Ops Manager API](../ops-man-api.html) topic.
 1. Click **Credentials** and record the Director credentials.
   <img src="../images/director-creds.png">
   You can also retrieve the credentials using the Ops Manager API at the following endpoint: `/api/v0/deployed/director/credentials/director_credentials`. You will need to authenticate to use the API. For more information, see the [Using the Ops Manager API](../ops-man-api.html) topic.

--- a/backup-restore/_bosh_target_director_bbr.html.md.erb
+++ b/backup-restore/_bosh_target_director_bbr.html.md.erb
@@ -6,6 +6,7 @@ You access the BOSH Director using this IP address.
   <img src="../images/director-ip.png">
 1. Click **Credentials** and record the Director credentials.
   <img src="../images/director-creds.png">
+  You can also retrieve the credentials using the Ops Manager API at the following endpoint: `/api/v0/deployed/director/credentials/director_credentials`. You will need to authenticate to use the API. For more information, see the [Using the Ops Manager API](../ops-man-api.html) topic.
 1. From the command line, log into the BOSH Director using the IP address and credentials that you recorded:
   <pre class='terminal'>
   $ bosh -e DIRECTOR_IP --ca-cert /var/tempest/workspaces/default/root\_ca\_certificate log-in

--- a/backup-restore/backup-pcf-bbr.html.md.erb
+++ b/backup-restore/backup-pcf-bbr.html.md.erb
@@ -241,11 +241,16 @@ Perform the following steps to back up your BOSH Director:
 1. Click the Ops Manager tile.
 1. Click the **Credentials** tab.
 1. Locate **Bbr Ssh Credentials** and click **Link to Credential** next to it.
-1. Copy the value for `private_key_pem`, beginning with `"-----BEGIN RSA PRIVATE KEY-----"` and paste it into a file that you save on your jumpbox.
+1. Copy the value for `private_key_pem`, beginning with `"-----BEGIN RSA PRIVATE KEY-----"`.
+1. SSH into your jumpbox.
+1. Run the following command to reformat the key and save it to a file called `PRIVATE_KEY` in the current directory, pasting in the contents of your private key for `YOUR_PRIVATE_KEY`:
+  <pre class="terminal">
+  printf -- "YOUR\_PRIVATE\_KEY" > PRIVATE_KEY
+  </pre>
 1. Run the BBR backup command from your jumpbox to back up your BOSH Director:
 	<pre class="terminal">
 	$ bbr director \
-	  --private-key-path PATH\_TO\_PRIVATE\_KEY \
+	  --private-key-path PRIVATE\_KEY \
 	  --username bbr \
 	  --host HOST \
 	  backup
@@ -255,7 +260,7 @@ Perform the following steps to back up your BOSH Director:
 	Use the optional `--debug` flag to enable debug logs. See the [Logging](#logging) section for more information.
 	<br><br>
 	Replace the placeholder values as follows:
-	* `PATH_TO_PRIVATE_KEY`: This is the path to the private key file you created above.
+	* `PRIVATE_KEY`: This is the path to the private key file you created above.
 	* `HOST`: This is the address of the BOSH Director. If the BOSH Director is public, this is a URL, such as `https://my-bosh.xxx.cf-app.com`. Otherwise, this is the `BOSH_DIRECTOR_IP`, which you retrieved in the [Step 4: Retrieve BOSH Director Address and Credentials](#retrieve) section.
 
 ## <a id='validate-backup'></a> Step 11: (Optional) Validate Your Backup

--- a/backup-restore/backup-pcf-bbr.html.md.erb
+++ b/backup-restore/backup-pcf-bbr.html.md.erb
@@ -64,6 +64,14 @@ restoring your installation.
 
 	<%= image_tag("ccdb-encrypt-creds.png") %>
 
+You can also retrieve the credentials using the Ops Manager API. To do this:
+
+* visit the following endpoint: `/api/v0/deployed/products`;
+* find the product with an `installation_name` starting with `cf-` and copy its `guid`;
+* visit the following endpoint: `/api/v0/deployed/products/:guid/credentials/.cloud_controller.db_encryption_credentials` (where `:guid` is the value you've just copied).
+
+You will need to authenticate to use the API. For more information, see the [Using the Ops Manager API](../ops-man-api.html) topic.
+
 ## <a id='backup-prepare-node'></a> Step 2: Enable Backup Prepare Node
 
 BBR requires the MySQL backup prepare node to be present in order to successfully backup ERT. Currently, the only way to ensure the presence of this node is to enable automated MySQL backups. If you already have these enabled, you may skip this section. In the future, there will be an option to deploy the backup prepare node without enabling automatic MySQL backups.
@@ -191,7 +199,7 @@ Perform the following steps to check that your BOSH Director is reachable and ha
 	</pre>
 
     Replace the placeholder values as follows:
-    * `BOSH_CLIENT`, `BOSH_CLIENT_SECRET`: From the Ops Manager Installation Dashboard, click **Ops Manager Director**, navigate to the **Credentials** tab, and click **Uaa Bbr Client Credentials** to retrieve the BOSH UAA credentials. You can also retrieve the credentials using the Ops Manager API at the following endpoint: `/api/v0/deployed/director/credentials/uaa_bbr_client_credentials`. For more information, see the [Using the Ops Manager API](../ops-man-api.html) topic.
+    * `BOSH_CLIENT`, `BOSH_CLIENT_SECRET`: From the Ops Manager Installation Dashboard, click **Ops Manager Director**, navigate to the **Credentials** tab, and click **Uaa Bbr Client Credentials** to retrieve the BOSH UAA credentials. You can also retrieve the credentials using the Ops Manager API at the following endpoint: `/api/v0/deployed/director/credentials/uaa_bbr_client_credentials`. You will need to authenticate to use the API. For more information, see the [Using the Ops Manager API](../ops-man-api.html) topic.
     * `BOSH_DIRECTOR_IP`: You retrieved this value in the [Step 4: Retrieve BOSH Director Address and Credentials](#retrieve) section.
     * `DEPLOYMENT-NAME`: You retrieved this value in the [Step 5: Identify Your Deployment](#identify-deployment) section.
     * `PATH_TO_BOSH_SERVER_CERT`: This is the path to the BOSH Director’s Certificate Authority (CA) certificate, if the certificate is not verifiable by the local machine’s certificate chain. If you are using the Ops Manager VM as your jumpbox, locate the certificate at `/var/tempest/workspaces/default/root_ca_certificate`. 
@@ -241,6 +249,9 @@ Perform the following steps to back up your BOSH Director:
 1. Click the Ops Manager tile.
 1. Click the **Credentials** tab.
 1. Locate **Bbr Ssh Credentials** and click **Link to Credential** next to it.
+
+    You can also retrieve the credentials using the Ops Manager API at the following endpoint: `/api/v0/deployed/director/credentials/bbr_ssh_credentials`. You will need to authenticate to use the API. For more information, see the [Using the Ops Manager API](../ops-man-api.html) topic.
+
 1. Copy the value for `private_key_pem`, beginning with `"-----BEGIN RSA PRIVATE KEY-----"`.
 1. SSH into your jumpbox.
 1. Run the following command to reformat the key and save it to a file called `PRIVATE_KEY` in the current directory, pasting in the contents of your private key for `YOUR_PRIVATE_KEY`:
@@ -255,7 +266,6 @@ Perform the following steps to back up your BOSH Director:
 	  --host HOST \
 	  backup
 	</pre>
-
 
 	Use the optional `--debug` flag to enable debug logs. See the [Logging](#logging) section for more information.
 	<br><br>

--- a/backup-restore/restore-pcf-bbr.html.md.erb
+++ b/backup-restore/restore-pcf-bbr.html.md.erb
@@ -114,7 +114,7 @@ Perform the following steps to retrieve the IP address of your BOSH Director and
   <br><br>
   Replace the placeholder values as follows:
   * `PATH_TO_DIRECTOR_BACKUP`: This is the path to the Director backup you want to restore.
-  * `PATH_TO_PRIVATE_KEY`: This is the path to the private key file you created above.
+  * `PRIVATE_KEY`: This is the path to the private key file you created above.
   * `HOST`: This is the address of the BOSH Director. If the BOSH Director is public, this will be a URL, such as `https://my-bosh.xxx.cf-app.com`. Otherwise, it will be the `BOSH_DIRECTOR_IP`, which you retrieved in the [Step 5: Retrieve BOSH Director Address and Credentials](#retrieve) section.
 
 <p class="note"><strong>Note</strong>: The BBR restore command can take a long time to complete. Pivotal recommends you run it independently of the SSH session, so that the process can continue running even if your connection to the jumpbox fails. The command above uses <code>nohup</code> but you could also run the command in a <code>screen</code> or <code>tmux</code> session.</p>

--- a/backup-restore/restore-pcf-bbr.html.md.erb
+++ b/backup-restore/restore-pcf-bbr.html.md.erb
@@ -94,6 +94,9 @@ Perform the following steps to retrieve the IP address of your BOSH Director and
 1. Click the Ops Manager tile.
 1. Click the **Credentials** tab.
 1. Locate **Bbr Ssh Credentials** and click **Link to Credential** next to it.
+
+    You can also retrieve the credentials using the Ops Manager API at the following endpoint: `/api/v0/deployed/director/credentials/bbr_ssh_credentials`. You will need to authenticate to use the API. For more information, see the [Using the Ops Manager API](../ops-man-api.html) topic.
+
 1. Copy the value for `private_key_pem`, beginning with `"-----BEGIN RSA PRIVATE KEY-----"`.
 1. SSH into your jumpbox.
 1. Run the following command to reformat the key and save it to a file called `PRIVATE_KEY` in the current directory, pasting in the contents of your private key for `YOUR_PRIVATE_KEY`:
@@ -194,13 +197,18 @@ $ BOSH\_CLIENT\_SECRET=BOSH_PASSWORD \
 
     Replace the placeholder values as follows:
     * `BOSH_CLIENT`, `BOSH_CLIENT_SECRET`: Use the BOSH UAA user provided in  **Pivotal Ops Manager > Credentials > Uaa Bbr Client Credentials**.
+       You can also retrieve the credentials using the Ops Manager API at the following endpoint: `/api/v0/deployed/director/credentials/uaa_bbr_client_credentials`. You will need to authenticate to use the API. For more information, see the [Using the Ops Manager API](../ops-man-api.html) topic.
     * `BOSH_DIRECTOR_IP`: You retrieved this value in the [Step 5: Retrieve BOSH Director Address and Credentials](#retrieve) section.
     * `DEPLOYMENT-NAME`: You retrieved this value in the [Step 7: Identify Your Deployment](#identify-deployment) section.
     * `PATH_TO_BOSH_SERVER_CERT`: This is the path to the BOSH Director’s Certificate Authority (CA) certificate, if the certificate is not verifiable by the local machine’s certificate chain.
     * `PATH_TO_ERT_BACKUP`: This is the path to the Elastic Runtime backup you want to restore.
 
 1. If you have Container-to-Container Networking enabled in the Elastic Runtime, perform the following steps after restoring Elastic Runtime:
-  1. Retrieve the MySQL admin password from **Pivotal Elastic Runtime > Credentials > Mysql Admin Credentials**.
+  1. Retrieve the MySQL admin password from **Pivotal Elastic Runtime > Credentials > Mysql Admin Credentials**. You can also retrieve the credentials using the Ops Manager API. To do this:
+      * visit the following endpoint: `/api/v0/deployed/products`;
+      * find the product with an `installation_name` starting with `cf-` and copy its `guid`;
+      * visit the following endpoint: `/api/v0/deployed/products/:guid/credentials/.mysql.mysql_admin_credentials` (where `:guid` is the value you've just copied).
+      * You will need to authenticate to use the API. For more information, see the [Using the Ops Manager API](../ops-man-api.html) topic.
   1. List the VMs in your deployment:
     <pre class="terminal">$ bosh -e DIRECTOR\_IP --ca-cert /var/tempest/workspaces/default/root\_ca\_certificate \
     -d DEPLOYMENT\_NAME \


### PR DESCRIPTION
This adds instructions on how to retrieve informations like the director IPs or credentials through the OpsManager API instead of the OpsManager UI. This should help the operators to automate the process.