### PR TITLE
cert vs dns mismatch

### DIFF
--- a/pcf-aws-manual-config.html.md.erb
+++ b/pcf-aws-manual-config.html.md.erb
@@ -677,7 +677,7 @@ The default persistent disk value is 50 GB. Pivotal recommends increasing this v
 1. Select the `pcf-ops-manager` instance you created in [Step 12: Launch a Pivotal Ops Manager AMI](#pcfaws-om-ami).
 1. On the **Description** tab, record the value for **IPv4 Public IP**.
 1. Navigate to your DNS provider and create the following CNAME and A records:
-  * CNAME: `*.apps.YOUR-SYSTEM-DOMAIN.com` and `*.sys.YOUR-SYSTEM-DOMAIN.com` points to the DNS name of the `pcf-web-elb` load balancer.
+  * CNAME: `*.apps.YOUR-SYSTEM-DOMAIN.com` and `*.system.YOUR-SYSTEM-DOMAIN.com` points to the DNS name of the `pcf-web-elb` load balancer.
   * CNAME: `ssh.YOUR-SYSTEM-DOMAIN.com` points to the DNS name of the `pcf-ssh-elb` load balancer.
   * CNAME: `tcp.YOUR-SYSTEM-DOMAIN.com` points to the DNS name of the `pcf-tcp-elb` load balancer.
   * A: `pcf.YOUR-SYSTEM-DOMAIN.com` points to the public IP address of the `pcf-ops-manager` EC2 instance.


### PR DESCRIPTION
https://docs.pivotal.io/pivotalcf/1-11/customizing/pcf-aws-manual-config.html (step 16.5)
suggests creating `*.sys.YOUR-SYSTEM-DOMAIN.com` dns enty.

https://docs.pivotal.io/pivotalcf/1-11/opsguide/security_config.html#aws_certs
suggests creating a cert with `*.system.yourdomain.com`.

shouldn't these two entries match?