### PR TITLE
Must remove default outbound security group rule for the MYSQL SG

### DIFF
--- a/pcf-aws-manual-config.html.md.erb
+++ b/pcf-aws-manual-config.html.md.erb
@@ -401,7 +401,8 @@ Perform the following steps to create an Amazon Identity and Access Management (
       <td>10.0.0.0/16</td>
     </tr>
     </table>
-1. Click the **Outbound** tab. Add a rule of type `All traffic` and specify the subnet of your VPC in **Destination**, as the table and image show.
+1. Click the **Outbound** tab and remove the default `All traffic` entry with destination 0.0.0.0/0.
+1. Add a rule of type `All traffic` and specify the subnet of your VPC in **Destination**, as the table and image show.
     <table border="1" class="nice" >
     <tr>
       <th><strong>Type </strong></th>


### PR DESCRIPTION
Must remove default outbound security group rule for the MYSQL Security Group

with the default entry still in place, scoping down to your vpc subnet won't do anything.