### PR TITLE
update elb health check `ping path` to `/health`

### DIFF
--- a/pcf-aws-manual-config.html.md.erb
+++ b/pcf-aws-manual-config.html.md.erb
@@ -519,6 +519,7 @@ The default persistent disk value is 50 GB. Pivotal recommends increasing this v
 1. On the **Configure Health Check** page, enter the following values:
   * **Ping Protocol**: Select **HTTP**.
   * **Ping Port**: Set to `8080`. 
+  * **Ping Path**: Set to `/health`. 
   * **Interval**: Set to `5` seconds. 
   * **Response Timeout**: Set to `3` seconds.
   * **Unhealthy threshold**: Set to `3`.


### PR DESCRIPTION
The documentation doesn't define a `ping path`, so the default is setup as `index.html` which is incorrect and the router instances will never become healthy to the elb.

Updating to `/health` is the correct configuration

https://github.com/cloudfoundry/gorouter