### PR TITLE
[1.11] Add warnings about restoring a BOSH Director in the same IaaS network as old VMs and disks

### DIFF
--- a/backup-restore/backup-pcf-bbr.html.md.erb
+++ b/backup-restore/backup-pcf-bbr.html.md.erb
@@ -298,6 +298,8 @@ You can also retrieve the credentials using the Ops Manager API with a GET reque
 
 ## <a id='validate-backup'></a> Step 11: (Optional) Validate Your Backup
 
+<p class="note warning"><strong>Warning</strong>: When validating your backup it is important that the VMs and disks from the backed up BOSH Director are not visible to the new BOSH Director. Therefore as part of backup validition it is highly recommended that the new BOSH Director is on a different IaaS network and account to the VMs and disks of the backed up BOSH Director.</p>
+
 After backing up PCF, you may want to validate your backup by restoring it to a similar environment and checking the applications. Because BBR is designed for disaster recovery, its backups are intended to be restored to an environment deployed with the same configuration.
 
 Perform the following steps to spin up a second environment that matches the original in order to test a restore:

--- a/backup-restore/restore-pcf-bbr.html.md.erb
+++ b/backup-restore/restore-pcf-bbr.html.md.erb
@@ -17,6 +17,8 @@ owner: RelEng
 
 <p class="note warning"><strong>Warning</strong>: Restoring Pivotal Cloud Foundry (PCF) with BBR is a destructive operation. If the restore fails, the new environment may be left in an unusable state and require reprovisioning. Only perform the procedures in this topic for the purpose of disaster recovery, such as recreating PCF after a storage-area network (SAN) corruption.</p>
 
+<p class="note warning"><strong>Warning</strong>: When restoring it is important that the VMs and disks from the old BOSH Director are not visible to the new restored BOSH Director. Therefore as part of a disaster recovery scenario it is highly recommended that you delete any old VMs or disks that are still present on the IaaS before proceeding.</p>
+
 <p class="note"><strong>Note</strong>: BBR is a beta feature in PCF v1.11. You can only use BBR to back up PCF v1.11 and later. To restore earlier versions of PCF, perform the <a href="restore-pcf.html">manual procedures</a>.</p>
 
 This topic describes the procedure for restoring your critical backend PCF components with BOSH Backup and Restore (BBR), a command-line tool for backing up and restoring BOSH deployments. To perform the procedures in this topic, you must have backed up Pivotal Cloud Foundry (PCF) by following the steps in the [Backing Up Pivotal Cloud Foundry with BBR](backup-pcf-bbr.html) topic.


### PR DESCRIPTION
This adds warnings to both the backup validation and restore sections about restoring a BOSH Director into a network with VMs or disks from the backed up BOSH Director. This should help operators avoid getting into this situation which would otherwise potentially have bad side effects on both the restored and the backed up systems.

(This is the same change as https://github.com/pivotal-cf/docs-pcf-install/pull/166 but for 1.11, hopefully this is the correct way to get a change into two branches)