### PR TITLE
Add steps to create AZ disk image to PCF AZ docs

### DIFF
--- a/azure-om-deploy.html.md.erb
+++ b/azure-om-deploy.html.md.erb
@@ -342,15 +342,24 @@ Azure for PCF uses multiple general-purpose Azure storage accounts. The BOSH and
     * For Azure Government Cloud, use `blob.core.usgovcloudapi.net`. See the [Azure documentation](https://docs.microsoft.com/en-us/azure/azure-government/documentation-government-services-storage) for more information.
     * For Azure Germany, use `blob.core.cloudapi.de`. See the [Azure documentation](https://docs.microsoft.com/en-us/azure/germany/germany-developer-guide) for more information.
 
+1. Create an Azure Image from the Ops Manager virtual disk image downloaded in the previous step.
+    <pre class="terminal">
+    $ az image create --resource-group $RESOURCE_GROUP \
+    --name opsman-img \
+    --source opsman-disk \
+    --location $LOCATION \
+    --os-type Linux
+    </pre>
+
 1. Create your Ops Manager VM, replacing `PATH-TO-PUBLIC-KEY` with the path to your public key `.pub` file.
     <pre class="terminal">
      $ az vm create --name ops-manager --resource-group $RESOURCE\_GROUP \
-     --location $LOCATION --os-type linux \
+     --location $LOCATION \
      --nics ops-manager-nic \
-     --attach-os-disk opsman-disk \
      --admin-username ubuntu \
      --size Standard\_DS2\_v2 \
-     --ssh-key-value PATH-TO-PUBLIC-KEY
+     --ssh-key-value PATH-TO-PUBLIC-KEY \
+     --image opsman-img
     </pre> 
 
 ##<a id='post-deploy'></a> Step 6: Complete Ops Manager Director Configuration


### PR DESCRIPTION
While working from these instructions to install PCF on Azure, I found a few differences in the way that the Azure API works today that could benefit from being back-filled into the PCF AZ Docs.

My main gotcha is at the very end, where you can no longer attach an OS disk image to a VM at creation time (you need to create a native AZ image from that disk image first, which is an additional step).