### PR TITLE
Warn users not to modify parameter adminUsername and delete confused instruction.

### DIFF
--- a/azure-arm-template.html.md.erb
+++ b/azure-arm-template.html.md.erb
@@ -111,9 +111,9 @@ Azure for PCF uses multiple general-purpose Azure storage accounts. The BOSH and
 
 ##<a id='configure'></a> Step 3: Configure the ARM Template
 
-1. Create a keypair on your local machine with the username `ubuntu`. For example, enter the following command:
+1. Create a keypair on your local machine. For example, enter the following command:
    <pre class="terminal">
-   $ ssh-keygen -t rsa -f opsman -C ubuntu
+   $ ssh-keygen -t rsa -f opsman
    </pre>
    <br>
    When prompted for a passphrase, press the `enter` key to provide an empty passphrase.
@@ -129,6 +129,7 @@ Azure for PCF uses multiple general-purpose Azure storage accounts. The BOSH and
     * **clientID**: Your client or application ID, retrieved in the [Preparing to Deploy PCF on Azure](azure-prepare-env.html) topic
     * **clientSecret**: Your client secret, created in the [Preparing to Deploy PCF on Azure](azure-prepare-env.html) topic
     * **vmSize**: The size of the Ops Manager VM. Pivotal recommends using `Standard_DS2_v2`.
+    * **adminUsername**: Username for Ops Manager VM. Please **DO NOT** change the default value `ubuntu` in case of any unexpected behaviors, including unable to connect to the VM via SSH and failure in further installation of Elastic Runtime.
     * **location**: The location where to install the Ops Manager VM. For example, `westus`.
 
 ##<a id='deploy'></a> Step 4: Deploy the ARM Template and Deployment Storage Accounts


### PR DESCRIPTION
…ons about it

1. Add explanation of parameter adminUsername in ARM Template's parameters, and warn users not to modify it in line 132.
There is no explanation for the parameter of adminUsername previously. Actually, modifying it may result in failure in the installation of Elastic Runtime and will cause the Ops Manager VM inaccessible via SSH. (Even users try to reset SSH key or password with Microsoft Azure's Portal) 

2. Remove confused explanation about username while generate SSH RSA key pair in line 116.
`-C ubuntu` only specifies the `comment` of the key pair to be 'ubuntu' and has nothing to do with username.
Modify the 'username' `ubuntu` simultaneously in the comment of key pair and parameters for ARM Template won't help in problems mentioned in previous section.