### PR TITLE
Updates to BBR docs from CloudOps' feedback

### DIFF
--- a/backup-restore/backup-pcf-bbr.html.md.erb
+++ b/backup-restore/backup-pcf-bbr.html.md.erb
@@ -175,10 +175,10 @@ Always export an installation before following the steps in the [Import Installa
 From the **Installation Dashboard** in the Ops Manager interface, click your user name at the top right navigation. Select **Settings**.
 
 **Export Installation Settings** exports the current PCF installation
-settings and assets.
-When you export an installation, the exported file contains the base VM images,
-all necessary packages, and references to the installation IP addresses.
-As a result, an exported installation file can exceed 5 GB in size.
+settings and assets. When you export an installation, the exported file contains the base VM images,
+all necessary packages, and references to the installation IP addresses. As a result, an exported installation file can exceed 5 GB in size.
+
+<p class="note"><strong>Note</strong>: Preparing and downloading the installation settings file will take around 5-15 minutes.</note>
 
 <p class="note">After exporting installation settings, Ops Manager will create a number of files in the <code>/tmp/ops_manager</code> directory on the Ops Manager VM and schedule a cleanup in one hour. Depending on the size of the VM, it may run out of disk space if you export multiple installations before the hourly cleanup runs.</p>
 
@@ -216,6 +216,8 @@ You can also retrieve the credentials using the Ops Manager API with a GET reque
 	* `PRIVATE_KEY`: This is the path to the private key file you created above.
 	* `HOST`: This is the address of the BOSH Director. If the BOSH Director is public, this is a URL, such as `https://my-bosh.xxx.cf-app.com`. Otherwise, this is the `BOSH_DIRECTOR_IP`, which you retrieved in the [Step 3: Retrieve BOSH Director Address and Credentials](#retrieve) section.
 
+	<p class="note"><strong>Note</strong>: The BOSH Director backup will take at least 20 minutes.</note>
+
 ### <a id='bbr-backup'></a> Step 9: Back Up Your Elastic Runtime Deployment
 
 Run the BBR backup command from your jumpbox to back up your Elastic Runtime deployment:
@@ -246,6 +248,8 @@ If the command fails, do the following:
 1. Ensure the BOSH Director credentials are valid.
 1. Ensure the specified deployment exists.
 1. Consult the [Exit Codes](#exit-codes) section below.
+
+<p class="note"><strong>Note</strong>: Backing up ERT takes at least 10 minutes, and can take considerably longer with larger blobstores or slow network connections. The backup also incurs around 10 minutes of Cloud Controller downtime, during which users will be unable to push, scale, or delete apps. Your apps will not be affected.</p>
 
 ### <a id='validate-backup'></a> Step 10: (Optional) Validate Your Backup
 

--- a/backup-restore/restore-pcf-bbr.html.md.erb
+++ b/backup-restore/restore-pcf-bbr.html.md.erb
@@ -83,7 +83,7 @@ If you recreate your IaaS resources, you must also add those resources to Ops Ma
 
     <p class="note"><strong>Note</strong>:
       Some browsers do not provide feedback on the status of the import process,
-      and may appear to hang.</p>
+      and may appear to hang. The import process will take at least 10 minutes, and will be longer the more tiles that were present on the backed up Ops Manager.</p>
 
 1. A **Successfully imported installation** message appears upon completion.
 
@@ -161,7 +161,7 @@ Perform the following steps to retrieve the IP address of your BOSH Director and
   * `PRIVATE_KEY`: This is the path to the private key file you created above.
   * `HOST`: This is the address of the BOSH Director. If the BOSH Director is public, this will be a URL, such as `https://my-bosh.xxx.cf-app.com`. Otherwise, it will be the `BOSH_DIRECTOR_IP`, which you retrieved in the [Step 5: Retrieve BOSH Director Address and Credentials](#retrieve) section.
 
-<p class="note"><strong>Note</strong>: The BBR restore command can take a long time to complete. Pivotal recommends you run it independently of the SSH session, so that the process can continue running even if your connection to the jumpbox fails. The command above uses <code>nohup</code> but you could also run the command in a <code>screen</code> or <code>tmux</code> session.</p>
+<p class="note"><strong>Note</strong>: The BBR director restore command can take a long time to complete - at least 15 minutes. Pivotal recommends you run it independently of the SSH session, so that the process can continue running even if your connection to the jumpbox fails. The command above uses <code>nohup</code> but you could also run the command in a <code>screen</code> or <code>tmux</code> session.</p>
 
 If the commands completes successfully, continue to [Step 8: Identify Your Deployment](#identify-deployment).
 

--- a/backup-restore/restore-pcf-bbr.html.md.erb
+++ b/backup-restore/restore-pcf-bbr.html.md.erb
@@ -95,6 +95,7 @@ If you recreated IaaS resources such as networks and load balancers by following
 
 1. Navigate to the Ops Manager Installation Dashboard and click the Ops Manager Director tile.
 1. Click **Create Networks** and update the network names to reflect the network names for the new environment.
+1. If running on GCP, click **Google Config** and update the **Project ID** to reflect the new GCP project ID.
 1. Return to the Ops Manager Installation Dashboard and click the Elastic Runtime tile.
 1. Click **Resource Config**. If necessary for your IaaS, enter the name of your new load balancer in the **Load Balancer** column.
 1. If necessary, click **Networking** and update the load balancer SSL certificate and private key under **Router SSL Termination Certificate and Private Key**.

--- a/backup-restore/restore-pcf-bbr.html.md.erb
+++ b/backup-restore/restore-pcf-bbr.html.md.erb
@@ -13,10 +13,6 @@ owner: RelEng
 .note.warning:before {
   color: #f99;
 }
-.note.validation {
-  background-color: #dce7c4;
-  border-color: #cedeac;
-}
 </style>
 
 This topic describes the procedure for restoring your critical backend PCF components with BOSH Backup and Restore (BBR), a command-line tool for backing up and restoring BOSH deployments. To perform the procedures in this topic, you must have backed up Pivotal Cloud Foundry (PCF) by following the steps in the [Backing Up Pivotal Cloud Foundry with BBR](backup-pcf-bbr.html) topic.
@@ -31,7 +27,7 @@ The procedures described in this topic prepare your environment for PCF, deploy 
 
 <p class="note"><strong>Note</strong>: BBR is a feature in PCF v1.11. You can only use BBR to back up PCF v1.11 and later. To restore earlier versions of PCF, perform the <a href="restore-pcf.html">manual procedures</a>.</p>
 
-<p class="note validation"><strong>Validation</strong>: If you are restoring in order to validate a backup, look for these green notes throughout the document.</p>
+<p class="note validation"><strong>Note</strong>: If you are restoring in order to validate a backup, look for notes marked <strong>Validation</strong> throughout the document.</p>
 
 ## <a id="compatibility"></a> Compatibility of Restore
 
@@ -117,7 +113,9 @@ If you recreated IaaS resources such as networks and load balancers by following
   </pre>
 1. Navigate to `YOUR-OPS-MAN-FQDN` in a browser and log into Ops Manager.
 1. For each tile that requires one, upload the required stemcell.
-1. Do not click **Apply Changes**. Instead, perform the steps in the [Applying Changes to Ops Manager Director](../deploy-ops-man-director.html) topic to use the Ops Manager API to only deploy the Ops Manager Director.
+<p class="note warning"><strong>Warning</strong>: Do not click "Apply Changes" at this point.</p>
+1. Perform the steps in the [Applying Changes to Ops Manager Director](../deploy-ops-man-director.html) topic to use the Ops Manager API to only deploy the Ops Manager Director.
+<p class="note"><strong>Validation</strong>: If your BOSH Director has an external hostname, you should change it in **Ops Manager Director > Director Config > Directory Hostname** to ensure it does not conflict with the hostname of the backed up Director.</p>
 
 ## <a id="artifacts-jumpbox"></a> Step 5: Transfer Artifacts to Jumpbox
 

--- a/backup-restore/restore-pcf-bbr.html.md.erb
+++ b/backup-restore/restore-pcf-bbr.html.md.erb
@@ -40,13 +40,12 @@ Consult the following restrictions for a backup artifact to be restorable:
 + **Topology**: BBR requires the BOSH topology of a deployment to be the same in the restore environment as it was in the backup environment.
 + **Naming of instance groups and jobs**: For any deployment that implements the backup and restore scripts, the instance groups and jobs must have the same names.
 + **Number of instance groups and jobs**: For instance groups and jobs that have backup and restore scripts, there must be the same number of instances.
-+ **Limited validation**: BBR puts the backed-up data into the corresponding instance groups and jobs in the restored environment,
++ **Limited validation**: BBR puts the backed up data into the corresponding instance groups and jobs in the restored environment,
     but can’t validate the restore beyond that.
     For example, if the MySQL encryption key is different in the restore environment,
     the BBR restore might succeed although the restored MySQL database is unusable.
 
-<p class="note"><strong>Note</strong>: A change in VM size or underlying hardware should not affect BBR’s ability to restore data,
-as long as there is adequate storage space to restore the data. </p>
+<p class="note"><strong>Note</strong>: A change in VM size or underlying hardware should not affect BBR’s ability to restore data, as long as there is adequate storage space to restore the data. </p>
 
 ## <a id='prepare-env'></a>(Optional) Step 1: Prepare Your Environment
 
@@ -56,8 +55,7 @@ If you need to recreate your IaaS resources, prepare your environment for PCF by
 
 <p class="note"><strong>Note</strong>: The instructions for installing PCF on Amazon Web Services (AWS) and OpenStack combine the procedures for preparing your environment and deploying Ops Manager into a single topic. The instructions for the other supported IaaSes split these procedures into two separate topics.</p>
 
-If you recreate your IaaS resources, you must also add those resources to Ops Manager by performing the procedures in
-the [(Optional) Step 3: Configure Ops Manager for New Resources](#config-new-resources) section.
+If you recreate your IaaS resources, you must also add those resources to Ops Manager by performing the procedures in the [(Optional) Step 3: Configure Ops Manager for New Resources](#config-new-resources) section.
 
 ## <a id='deploy-import'></a>Step 2: Deploy Ops Manager and Import Installation Settings ##
 

--- a/backup-restore/restore-pcf-bbr.html.md.erb
+++ b/backup-restore/restore-pcf-bbr.html.md.erb
@@ -236,6 +236,7 @@ Scanning 19 persistent disks: 19 OK, 0 missing ...
       upload-stemcell \
       --fix PATH\_TO\_STEMCELL
   </pre>
+1. If you have any other tiles installed, ensure you upload their stemcells (if different from the ERT stemcell) to the BOSH Director with `bosh upload-stemcell --fix` as above.
 1. From the Ops Manager Installation Dashboard, navigate to **Pivotal Elastic Runtime > Resource Config**.
 1. Ensure the number of instances for MySQL Server is set to `1`.
   <p class="note warning"><strong>Warning</strong>: Restore will fail if there is not exactly one MySQL Server instance deployed.</p>

--- a/backup-restore/restore-pcf-bbr.html.md.erb
+++ b/backup-restore/restore-pcf-bbr.html.md.erb
@@ -13,6 +13,10 @@ owner: RelEng
 .note.warning:before {
   color: #f99;
 }
+.note.validation {
+  background-color: #dce7c4;
+  border-color: #cedeac;
+}
 </style>
 
 This topic describes the procedure for restoring your critical backend PCF components with BOSH Backup and Restore (BBR), a command-line tool for backing up and restoring BOSH deployments. To perform the procedures in this topic, you must have backed up Pivotal Cloud Foundry (PCF) by following the steps in the [Backing Up Pivotal Cloud Foundry with BBR](backup-pcf-bbr.html) topic.
@@ -27,24 +31,26 @@ The procedures described in this topic prepare your environment for PCF, deploy 
 
 <p class="note"><strong>Note</strong>: BBR is a feature in PCF v1.11. You can only use BBR to back up PCF v1.11 and later. To restore earlier versions of PCF, perform the <a href="restore-pcf.html">manual procedures</a>.</p>
 
+<p class="note validation"><strong>Validation</strong>: If you are restoring in order to validate a backup, look for these green notes throughout the document.</p>
+
 ## <a id="compatibility"></a> Compatibility of Restore
 
-This section describes the restrictions for a backup artifact to be restorable to another environment. 
-This section is for guidance only, and Pivotal highly recommends that operators validate their backups by 
-using the backup artifacts in a restore. 
+This section describes the restrictions for a backup artifact to be restorable to another environment.
+This section is for guidance only, and Pivotal highly recommends that operators validate their backups by
+using the backup artifacts in a restore.
 
 Consult the following restrictions for a backup artifact to be restorable:
 
-+ **Topology**: BBR requires the BOSH topology of a deployment to be the same in the restore environment as it was in the backup environment. 
-+ **Naming of instance groups and jobs**: For any deployment that implements the backup and restore scripts, the instance groups and jobs must have the same names. 
-+ **Number of instance groups and jobs**: For instance groups and jobs that have backup and restore scripts, there must be the same number of instances. 
-+ **Limited validation**: BBR puts the backed-up data into the corresponding instance groups and jobs in the restored environment, 
-    but can’t validate the restore beyond that. 
-    For example, if the MySQL encryption key is different in the restore environment, 
-    the BBR restore might succeed although the restored MySQL database is unusable. 
++ **Topology**: BBR requires the BOSH topology of a deployment to be the same in the restore environment as it was in the backup environment.
++ **Naming of instance groups and jobs**: For any deployment that implements the backup and restore scripts, the instance groups and jobs must have the same names.
++ **Number of instance groups and jobs**: For instance groups and jobs that have backup and restore scripts, there must be the same number of instances.
++ **Limited validation**: BBR puts the backed-up data into the corresponding instance groups and jobs in the restored environment,
+    but can’t validate the restore beyond that.
+    For example, if the MySQL encryption key is different in the restore environment,
+    the BBR restore might succeed although the restored MySQL database is unusable.
 
-<p class="note"><strong>Note</strong>: A change in VM size or underlying hardware should not affect BBR’s ability to restore data, 
-as long as there is adequate storage space to restore the data. </p> 
+<p class="note"><strong>Note</strong>: A change in VM size or underlying hardware should not affect BBR’s ability to restore data,
+as long as there is adequate storage space to restore the data. </p>
 
 ## <a id='prepare-env'></a>(Optional) Step 1: Prepare Your Environment
 
@@ -241,8 +247,13 @@ Scanning 19 persistent disks: 19 OK, 0 missing ...
 1. Ensure the number of instances for MySQL Server is set to `1`.
   <p class="note warning"><strong>Warning</strong>: Restore will fail if there is not exactly one MySQL Server instance deployed.</p>
 1. Return to the Ops Manager Installation Dashboard and click **Apply Changes** to redeploy.
+  <p class="note validation"><strong>Validation</strong>: If your ERT uses an external blobstore, ensure that the ERT tile is configured to use a different blobstore before clicking "Apply Changes", otherwise it will attempt to connect to the blobstore the existing ERT is using.</p>
+  <p class="note validation"><strong>Validation</strong>: Make sure your **System Domain** and **Apps Domain** under **Pivotal Elastic Runtime > Domains** are updated to refer to the validation environment.
+  </p>
 
 ## <a id='restore-ert'></a> Step 11: Restore Elastic Runtime
+
+<p class="note validation"><strong>Validation</strong>: If your apps must not be running after a restore (e.g. if they would alter state in a shared datastore), run <code>bosh stop</code> on each <code>diego_cell</code> VM in the deployment.</p>
 
 1. Run the BBR restore command from your jumpbox to restore Elastic Runtime:
 <pre class="terminal">
@@ -265,6 +276,10 @@ $ BOSH\_CLIENT\_SECRET=BOSH\_PASSWORD \
     * `DEPLOYMENT-NAME`: You retrieved this value in the [Step 8: Identify Your Deployment](#identify-deployment) section.
     * `PATH_TO_BOSH_SERVER_CERT`: This is the path to the BOSH Director’s Certificate Authority (CA) certificate, if the certificate is not verifiable by the local machine’s certificate chain.
     * `PATH_TO_ERT_BACKUP`: This is the path to the Elastic Runtime backup you want to restore.
+
+    <p class="note validation">
+      <strong>Validation</strong>: If you ran <code>bosh stop</code> on each <code>diego_cell</code> before running <code>bbr restore</code>, you can now run <code>cf stop</code> on all apps and then run <code>bosh start</code> on each <code>diego_cell</code>. After this, all apps will be deployed in a stopped state.
+    </p>
 
 1. Perform the following steps after restoring Elastic Runtime:
   1. Retrieve the MySQL admin password by following one of the procedures below:


### PR DESCRIPTION
CloudOps ran a backup and validated it by running a restore - we've made some fixes per their recommendations.

We've also added "Validation" notes to the restore flow - i.e., if you're just validating a backup rather than restoring in a disaster scenario, there are some extra notes to follow. Originally we wanted to make these notes a different colour so they can be easily identified, but I think that's not allowed. @bentarnoff - do you have any suggestions on how to make them distinct?

(The issue we're trying to solve here is that restore and validation are almost exactly the same, so we don't want to have to maintain two separate flows.)

cc @thereses 