### PR TITLE
fix enable backup prepare node step

### DIFF
--- a/backup-restore/backup-pcf-bbr.html.md.erb
+++ b/backup-restore/backup-pcf-bbr.html.md.erb
@@ -102,7 +102,8 @@ BBR requires the MySQL backup prepare node to be present in order to successfull
 Perform the following steps to enable the backup prepare node:
 
 1. In the Elastic Runtime tile, click **Internal MySQL**.
-1. Under **Automated Backups Configuration**, select **Disable automated backups of MySQL**.
+1. Under **Automated Backups Configuration**, select **Enable automated backups from MySQL to an S3 bucket or other S3-compatible file store**. Fill in the required fields with any text value, and set the **Cron Schedule** to a cron-formatted date that doesn't exist. For example, use February 31: `0 0 31 2 *`.
+ 	<p class="note"><strong>Note</strong>: If you do not enable automated backups, the BBR backup will fail.</p>
 1. Click **Resource Config** and use the dropdown menu to scale up the **Backup Prepare Node** to one instance.
 	<%= image_tag("backup-prepare-node.png") %>
 1. Navigate back to the Ops Manager Installation Dashboard and click **Apply Changes** to redeploy.


### PR DESCRIPTION
I think perhaps the 1.12 docs change got merged into the 1.11 branch. 