### PR TITLE
Add notes for backing up external blobstore in pcf-install docs

### DIFF
--- a/backup-restore/backup-pcf-bbr.html.md.erb
+++ b/backup-restore/backup-pcf-bbr.html.md.erb
@@ -228,7 +228,18 @@ $ BOSH\_CLIENT\_SECRET=BOSH\_PASSWORD \
 
 Use the optional `--debug` flag to enable debug logs. See the [Logging](#logging) section for more information.
 
-Use the optional `--with-manifest` flag to ensure that BBR downloads your current deployment manifest when backing up. These manifests are included in the Ops Manager export, but are useful for reference.
+Use the optional `--with-manifest` flag to ensure that BBR downloads your current deployment manifest when backing up. These manifests are included in the Ops Manager export, but are useful for reference. For example:
+<pre class="terminal">
+$ BOSH\_CLIENT\_SECRET=BOSH\_PASSWORD \
+  nohup bbr deployment \
+  --target BOSH\_DIRECTOR\_IP \
+  --username BOSH\_CLIENT \
+  --deployment DEPLOYMENT\_NAME \
+  --ca-cert PATH\_TO\_BOSH\_SERVER\_CERT \
+  backup --with-manifest</pre>
+
+
+<p class="note"><strong>External Blobstores</strong>: If you are using an external blobstore, create a copy of the blobstore with your IaaS specific tool. This might give you backups that are inconsistent, since backups of the blobstore and ERT might not match completely. But we recommend this solution til we add support for external blobstores.</p>
 
 <p class="note"><strong>Note</strong>: Backing up Elastic Runtime takes at least 10 minutes, and can take considerably longer with larger blobstores or slow network connections. The backup also incurs around 10 minutes of Cloud Controller downtime, during which users will be unable to push, scale, or delete apps. Your apps will not be affected.</p>
 

--- a/backup-restore/backup-pcf-bbr.html.md.erb
+++ b/backup-restore/backup-pcf-bbr.html.md.erb
@@ -239,7 +239,7 @@ $ BOSH\_CLIENT\_SECRET=BOSH\_PASSWORD \
   backup --with-manifest</pre>
 
 
-<p class="note"><strong>External Blobstores</strong>: If you are using an external blobstore, create a copy of the blobstore with your IaaS specific tool. This might give you backups that are inconsistent, since backups of the blobstore and ERT might not match completely. But we recommend this solution til we add support for external blobstores.</p>
+<p class="note"><strong>External Blobstores</strong>: If you are using an external blobstore, create a copy of the blobstore with your IaaS specific tool. Your blobstore backup could potentially be slightly inconsistent with your ERT backup. </p>
 
 <p class="note"><strong>Note</strong>: Backing up Elastic Runtime takes at least 10 minutes, and can take considerably longer with larger blobstores or slow network connections. The backup also incurs around 10 minutes of Cloud Controller downtime, during which users will be unable to push, scale, or delete apps. Your apps will not be affected.</p>
 

--- a/backup-restore/restore-pcf-bbr.html.md.erb
+++ b/backup-restore/restore-pcf-bbr.html.md.erb
@@ -17,7 +17,7 @@ owner: RelEng
 
 This topic describes the procedure for restoring your critical backend PCF components with BOSH Backup and Restore (BBR), a command-line tool for backing up and restoring BOSH deployments. To perform the procedures in this topic, you must have backed up Pivotal Cloud Foundry (PCF) by following the steps in the [Backing Up Pivotal Cloud Foundry with BBR](backup-pcf-bbr.html) topic.
 
-To view the BBR release notes, see the <a href="https://docs.pivotal.io/bbr/bbr-rn.html">BOSH Backup and Restore Release Notes</a>. 
+To view the BBR release notes, see the <a href="https://docs.pivotal.io/bbr/bbr-rn.html">BOSH Backup and Restore Release Notes</a>.
 
 The procedures described in this topic prepare your environment for PCF, deploy Ops Manager, import your installation settings, and use BBR to restore your PCF components.
 
@@ -107,7 +107,7 @@ If you recreated IaaS resources such as networks and load balancers by following
 1. SSH into your Ops Manager VM. For more information, see the [SSH into Ops Manager](../trouble-advanced.html#ssh) section of the <em>Advanced Troubleshooting with the BOSH CLI</em> topic.
 1. On the Ops Manager VM, delete the `/var/tempest/workspaces/default/deployments/bosh-state.json` file:
   <pre class="terminal">
-  $ rm /var/tempest/workspaces/default/deployments/bosh-state.json
+  $ sudo rm /var/tempest/workspaces/default/deployments/bosh-state.json
   </pre>
 1. Navigate to `YOUR-OPS-MAN-FQDN` in a browser and log into Ops Manager.
 1. For each tile that requires one, upload the required stemcell.

--- a/backup-restore/restore-pcf-bbr.html.md.erb
+++ b/backup-restore/restore-pcf-bbr.html.md.erb
@@ -251,6 +251,8 @@ Scanning 19 persistent disks: 19 OK, 0 missing ...
 
 <p class="note validation"><strong>Validation</strong>: If your apps must not be running after a restore run <code>bosh stop</code> on each <code>diego_cell</code> VM in the deployment.</p>
 
+<p class="note"><strong>External Blobstores</strong>: If you use an external blobstore, and have taken a copy of your blobstore during the backup, restore the external blobstore with your IAAS specific tools before running ERT restore.</p>
+
 1. Run the BBR restore command from your jumpbox to restore Elastic Runtime:
 <pre class="terminal">
 $ BOSH\_CLIENT\_SECRET=BOSH\_PASSWORD \


### PR DESCRIPTION
This change needs to go in 1.11 docs as well.

cc: @tinygrasshopper 