### PR TITLE
Add reference to OpsMan advanced mode in Step 3 of the BBR restore procedure

### DIFF
--- a/backup-restore/restore-pcf-bbr.html.md.erb
+++ b/backup-restore/restore-pcf-bbr.html.md.erb
@@ -93,6 +93,7 @@ If you recreate your IaaS resources, you must also add those resources to Ops Ma
 
 If you recreated IaaS resources such as networks and load balancers by following the steps in the [(Optional) Step 1: Prepare Your Environment](#prepare-env) section above, perform the following steps to update Ops Manager with your new resources:
 
+1. Enable the Ops Manager advanced mode following this [Knowledge Base article](https://discuss.pivotal.io/hc/en-us/articles/219118768-How-to-enable-advanced-mode-in-the-Ops-Manager).
 1. Navigate to the Ops Manager Installation Dashboard and click the Ops Manager Director tile.
 1. Click **Create Networks** and update the network names to reflect the network names for the new environment.
 1. If running on GCP, click **Google Config** and update the **Project ID** to reflect the new GCP project ID.
@@ -101,6 +102,7 @@ If you recreated IaaS resources such as networks and load balancers by following
 1. If necessary, click **Networking** and update the load balancer SSL certificate and private key under **Router SSL Termination Certificate and Private Key**.
 1. If your environment has a new DNS address, update the old environment DNS entries to point to the new load balancer addresses. For more information, see the [Step 4: Configure Networking](../custom-load-balancer.html#configure-networking) section of the <em>Using Your Own Load Balancer</em> topic and follow the link to the instructions for your IaaS.
 1. If you are using Google Cloud Platform (GCP), navigate to the **Google Config** section of the Ops Manager Director tile and update the **Default Deployment Tag** to reflect the new environment.
+1. Make sure you disable the Ops Manager advanced mode, as recommended in the [Knowledge Base article](https://discuss.pivotal.io/hc/en-us/articles/219118768-How-to-enable-advanced-mode-in-the-Ops-Manager).
 
 ## <a id="bosh-state"></a> Step 4: Remove BOSH State File
 


### PR DESCRIPTION
As per feedback by the master pipeline team, step 3 of the BBR restore procedure is actually invalid as the network settings are locked by Ops Manager after importing the installation settings.

Network settings can still be updated by enabling _advanced mode_ on Ops Man as described [here](https://discuss.pivotal.io/hc/en-us/articles/219118768-How-to-enable-advanced-mode-in-the-Ops-Manager). This PR adds instructions to enable, and then disable, advanced mode on Ops Man by following the KB article.