### PR TITLE
Clarify scaling App Autoscaler instructions

### DIFF
--- a/upgrading-pcf.html.md.erb
+++ b/upgrading-pcf.html.md.erb
@@ -131,7 +131,7 @@ Ensure that you complete the following as part of the upgrade:
 
 ### <a id="autoscaler"></a>Prep 9: Scale Down App Autoscaler
 
-Before upgrading to PCF v1.11, operators must scale down the App Autoscaler service to one instance. Otherwise, the App Autoscaler may panic and fail due to leader elections conflicts.
+Before upgrading to PCF v1.11, if you are using App Autoscaler, operators must scale down the service to one instance. Otherwise, the App Autoscaler may panic and fail due to leader elections conflicts.
 
 Perform the following steps:
 


### PR DESCRIPTION
Clarifies that this step is only required if you are using App Autoscaler.