### PR TITLE
Removed unnecessary note content

### DIFF
--- a/gcp-er-config.html.md.erb
+++ b/gcp-er-config.html.md.erb
@@ -351,12 +351,12 @@ the cf CLI tool. See <a href="../adminguide/cli-user-management.html">Creating a
 
 1. If you have enabled TCP routing in the <a href="#advanced-features">Advanced Features</a> pane and set up the <a href="./gcp-prepare-env.html#tcp_websockets_lb">TCP Load Balancer in GCP</a>, add the name of your TCP load balancer, prepended with <code>tcp:</code>, to the <strong>LOAD BALANCERS</strong> column of the <storng>TCP Router</strong> row. For example, <code>tcp:pcf-tcp-router</code>.
 
-1. Enter the name of you SSH load balancer depending on which release you are using.
+1. Enter the name of your SSH load balancer depending on which release you are using.
   * **Elastic Runtime**: Under the **LOAD BALANCERS** column of the **Diego Brain** row, enter the name of your SSH load balancer prepended with `tcp:`. For example, `tcp:MY-PCF-ssh-proxy`.
   * **Small Footprint Runtime**: Under the **LOAD BALANCERS** column of the **Control** row, enter the name of your SSH load balancer prepended with `tcp:`. 
 
 1. Verify that the **Internet Connected** checkbox for every job is unchecked. When preparing your GCP environment, you provisioned a Network Address Translation (NAT) box to provide Internet connectivity to your VMs instead of providing them with public IP addresses to allow the jobs to reach the Internet.
-   <p class="note"><strong>Note</strong>: If you want to provision a Network Address Translation (NAT) box to provide Internet connectivity to your VMs instead of providing them with public IP addresses, deselect the <strong>Internet Connected</strong> checkboxes. For more information about using NAT in GCP, see the <a href="https://cloud.google.com/compute/docs/networking">GCP documentation</a>.</p>  
+   <p class="note"><strong>Note</strong>: For more information about using NAT in GCP, see the <a href="https://cloud.google.com/compute/docs/networking">GCP documentation</a>.</p>  
 
 1. Click **Save**.
 


### PR DESCRIPTION
The recommendation for the `Internet Connected` setting has changed between PCF 1.11 and PCF 1.12 and a NAT box is now created, so the majority of the content of the note now reads as a duplicate of the line above it. This cleans that up. Also fixed a typo.