### PR TITLE
Document ideal location for metadata backup files

### DIFF
--- a/modify-ops-man.html.md.erb
+++ b/modify-ops-man.html.md.erb
@@ -51,7 +51,7 @@ Perform the following steps to locate, decrypt, and edit your Ops Manager instal
     $ sudo -u tempest-web ./decrypt /var/tempest/workspaces/default/installation.yml /tmp/installation.yml
     </pre>
 1. Open `/tmp/installation.yml` to view or edit values.
-1. If you plan to make changes, make a backup of the original installation YAML file:
+1. If you plan to make changes, make a backup of the original installation YAML file making sure that the backup is placed in a directory outside `/var/tempest/workspaces/default/`:
     <pre class="terminal">
     $ cp /var/tempest/workspaces/default/installation.yml ~/installation-orig.yml
     </pre>
@@ -81,7 +81,7 @@ Perform the following steps to locate and edit your Ops Manager product template
     <pre class="terminal">
     $ cd /var/tempest/workspaces/default/metadata
     </pre>
-1. The `/var/tempest/workspaces/default/metadata` directory contains the product templates as YAML files. If you plan to make changes, make a backup of the original product template YAML file:
+1. The `/var/tempest/workspaces/default/metadata` directory contains the product templates as YAML files. If you plan to make changes, make a backup of the original product template YAML file making sure that the backup is placed in a directory outside `/var/tempest/workspace/default/metadata/`:
     <pre class="terminal">
     $ cp /var/tempest/workspace/default/metadata/YOUR-PRODUCT-TEMPLATE.yml ~/YOUR-PRODUCT-TEMPLATE-orig.yml
     </pre>


### PR DESCRIPTION
Backing up these files within the same directories as the original will result in OpsMan failing to restart. We think this is because OpsManager attempts to load all yaml files in the respective directories. The instructions are using a different directory as example of where to take the backup, however it is not obvious/explicit in the docs.

cc @mariantalla