### PR TITLE
add link to port docs from firewall page

### DIFF
--- a/config_firewall.html.md.erb
+++ b/config_firewall.html.md.erb
@@ -19,7 +19,7 @@ Ops Manager and Elastic Runtime require the following open TCP ports:
 UDP port **123** must be open if you want to use an external NTP server.
 
 For more information about required ports for additional installed products,
-refer to the product documentation.
+refer to the [Network Communication Paths](https://docs.pivotal.io/pivotalcf/1-12/security/networking/index.html#net_commpaths) and other product documentation.
 
 The following example procedure uses iptables commands to configure a firewall.
 


### PR DESCRIPTION
inspired by a request from a customer in the EAP