### PR TITLE
Make upload stemcell step in BBR restore clearer

### DIFF
--- a/backup-restore/restore-pcf-bbr.html.md.erb
+++ b/backup-restore/restore-pcf-bbr.html.md.erb
@@ -101,7 +101,7 @@ If you recreated IaaS resources such as networks and load balancers by following
   $ rm /var/tempest/workspaces/default/deployments/bosh-state.json
   </pre>
 1. Navigate to `YOUR-OPS-MAN-FQDN` in a browser and log into Ops Manager.
-1. Upload the required stemcell for each tile that requires one, excluding Elastic Runtime. You upload the stemcell for Elastic Runtime in Step 11.
+1. Upload the required stemcell for each tile that requires one. (This will be apparent if the tile has an orange indicator at the bottom. When clicked, the 'Stemcell' panel will have an orange circle beside it.)
 <p class="note warning"><strong>Warning</strong>: Do not click <strong>Apply Changes</strong> at this point.</p>
 
 ## <a id="bosh-only-deploy"></a> Step 5: Deploy Ops Manager Director


### PR DESCRIPTION
Updates the wording of this step to make it more obvious that only tiles that are complaining about missing a stemcell need attention.

Chunyi && @henryaj 

[#153664603]