### PR TITLE
[1.12] Remove rollback-ert-bbr.html from docs

### DIFF
--- a/backup-restore/backup-pcf-bbr.html.md.erb
+++ b/backup-restore/backup-pcf-bbr.html.md.erb
@@ -19,7 +19,7 @@ During the backup, BBR stops the Cloud Controller API and the Cloud Controller w
   <strong>Warnings</strong>:
   <ul>
     <li><strong>Backup artifacts can contain secrets.</strong> Secure backup artifacts by using encryption or other means. </li>
-    <li><strong>The restore is a destructive operation.</strong> BBR is designed to restore PCF after a disaster. If it fails, the environment may be left in an unusable state and require reprovisioning. The two restore scenarios currently documented are <a href="restore-pcf-bbr.html">Restoring Pivotal Cloud Foundry from Backup with BBR</a> and <a href="rollback-ert-bbr.html">Rolling Back Elastic Runtime Deployment to an Earlier Backup with BBR</a>.</li>
+    <li><strong>The restore is a destructive operation.</strong> BBR is designed to restore PCF after a disaster. If it fails, the environment may be left in an unusable state and require reprovisioning. The two restore scenarios currently documented are <a href="restore-pcf-bbr.html">Restoring Pivotal Cloud Foundry from Backup with BBR</a> and <a href="in-place-restore.html">Restoring an ERT Backup In-place</a>.</li>
     <li><strong>The Cloud Controller API will stop sending and receiving calls</strong> for the duration of PCF restoration.</li>
     <li><strong>BBR does not back up any service data.</strong></li>
     <li><strong>Using an external blobstore or an external MySQL database results in an unusable restore</strong> even if the restore appears to run successfully.</li>

--- a/backup-restore/index.html.md.erb
+++ b/backup-restore/index.html.md.erb
@@ -27,6 +27,4 @@ To restore your PCF deployment with BBR, see <a href="restore-pcf-bbr.html" clas
 
 To use BBR to back up and restore your PCF deployment, you must first set up a jumpbox to run BBR from. See [Setting Up Your Jumpbox for BBR](system-setup-bbr.html).
 
-To use BBR to restore an Elastic Runtime deployment to a backup from a previous version, see [Rolling Back ERT Deployment to an Earlier Backup with BBR](rollback-ert-bbr.html).
-
 To troubleshoot problems with BBR, see [Troubleshooting BBR](troubleshooting-bbr.html).

--- a/backup-restore/restore-pcf-bbr.html.md.erb
+++ b/backup-restore/restore-pcf-bbr.html.md.erb
@@ -398,10 +398,6 @@ If you have on-demand service instances provisioned by an on-demand service brok
   </pre>
 1. Any Elastic Runtime apps bound to these services must be restarted to pick up the recreated service instances.
 
-## <a id="rollback"></a>Rolling Back Elastic Runtime in the Event of a Failed Upgrade
-
-If you have previously backed up PCF using BBR, you can roll back Elastic Runtime to an earlier deployment if the Elastic Runtime upgrade fails. For instructions, see the [Rolling Back Elastic Runtime Deployment to an Earlier Backup with BBR](rollback-ert-bbr.html) topic.
-
 ## <a id='removing-disks'></a> Remove Unused Disks
 
 If `bosh cck` does not clean up all disk references, you must manually delete the disks from a previous deployment that will prevent recreated deployments from working.

--- a/upgrading-pcf.html.md.erb
+++ b/upgrading-pcf.html.md.erb
@@ -284,12 +284,8 @@ Perform the following steps:
 
 1. Click each service tile, select the **Status** tab, and confirm that all VMs appear and are in good health.
 
-## <a id="after-upgrade"></a>After you Upgrade 
+## <a id="after-upgrade"></a>After you Upgrade
 
 ### <a id="cli-upgrade"></a>Upgrade cf CLI
 
-To use the experimental push commands, [multiple buildpack](../buildpacks/use-multiple-buildpacks.html) support, and [container networking commands](../devguide/deploy-apps/cf-networking.html#create-policies) in PCF 1.12, users must upgrade to cf CLI v6.30 or later. 
-
-## <a id="rollback"></a>Rolling Back ERT in the Event of a Failed Upgrade
-
-If you have previously backed up PCF using BOSH Backup and Restore, you can roll back Elastic Runtime (ERT) to an earlier deployment if the ERT upgrade fails. For instructions about rolling back the ERT deployment, see [Rolling Back ERT Deployment to an Earlier Backup with BBR](backup-restore/rollback-ert-bbr.html).
+To use the experimental push commands, [multiple buildpack](../buildpacks/use-multiple-buildpacks.html) support, and [container networking commands](../devguide/deploy-apps/cf-networking.html#create-policies) in PCF 1.12, users must upgrade to cf CLI v6.30 or later.

--- a/upgrading-products.html.md.erb
+++ b/upgrading-products.html.md.erb
@@ -40,15 +40,11 @@ To upgrade Elastic Runtime for PCF without upgrading Ops Manager, follow the pro
 1. Click the newly added tile to review any configurable options.
 1. Click **Apply Changes** to install the service.
 
-### <a id="rollback"></a>Rolling Back ERT in the Event of a Failed Upgrade
-
-If you have previously backed up PCF using BOSH Backup and Restore, you can roll back Elastic Runtime (ERT) to an earlier deployment if the ERT upgrade fails. For instructions about rolling back the ERT deployment, see [Rolling Back ERT Deployment to an Earlier Backup with BBR](backup-restore/rollback-ert-bbr.html).
-
 ##<a id="other-products"></a>Upgrading PCF Products ##
 
 <p class="note"><strong>Note</strong>: If you are using the <a href="../customizing/add-delete.html#pivnet-api">Pivotal Network API</a>, the latest product versions will automatically appear in your <strong>Installation Dashboard</strong>.</p>
 
-This section describes how to upgrade individual products like [Single Sign-On for PCF](http://docs.pivotal.io/p-identity/index.html), [MySQL for PCF](http://docs.pivotal.io/p-mysql/index.html), [RabbitMQ&reg; for PCF](http://docs.pivotal.io/rabbitmq-cf/index.html), and [Metrics for PCF](http://docs.pivotal.io/pcf-metrics/index.html) in your Pivotal Cloud Foundry (PCF) deployment. Ensure you review the individual product upgrade procedure for each tile. 
+This section describes how to upgrade individual products like [Single Sign-On for PCF](http://docs.pivotal.io/p-identity/index.html), [MySQL for PCF](http://docs.pivotal.io/p-mysql/index.html), [RabbitMQ&reg; for PCF](http://docs.pivotal.io/rabbitmq-cf/index.html), and [Metrics for PCF](http://docs.pivotal.io/pcf-metrics/index.html) in your Pivotal Cloud Foundry (PCF) deployment. Ensure you review the individual product upgrade procedure for each tile.
 
 1. Browse to [Pivotal Network](https://network.pivotal.io/) and sign in.
 


### PR DESCRIPTION
This is the 1.12 version of https://github.com/pivotal-cf/docs-pcf-install/pull/271