### PR TITLE
[1.12] Update drop tables to drop tables if exists for silk

### DIFF
--- a/backup-restore/in-place-restore.html.md.erb
+++ b/backup-restore/in-place-restore.html.md.erb
@@ -98,7 +98,7 @@ $ BOSH_CLIENT_SECRET=BOSH-PASSWORD \
   1. From the `mysql` VM, run the following command:
     <pre class="terminal">$ sudo /var/vcap/packages/mariadb/bin/mysql -u root -p</pre> When prompted, enter the MySQL admin password.<br><br>
   1. At the MySQL prompt, run the following command:
-    <pre class="terminal">mysql> use silk; drop table subnets; drop table gorp_migrations;</pre>
+    <pre class="terminal">mysql> use silk; drop table if exists subnets; drop table if exists gorp_migrations;</pre>
   1. Exit MySQL:
     <pre class="terminal">mysql> exit</pre>
   1. Exit the `mysql` VM:

--- a/backup-restore/restore-pcf-bbr.html.md.erb
+++ b/backup-restore/restore-pcf-bbr.html.md.erb
@@ -311,7 +311,7 @@ $ BOSH_CLIENT_SECRET=BOSH-PASSWORD \
   1. From the `mysql` VM, run the following command:
     <pre class="terminal">$ sudo /var/vcap/packages/mariadb/bin/mysql -u root -p</pre> When prompted, enter the MySQL admin password.<br><br>
   1. At the MySQL prompt, run the following command:
-    <pre class="terminal">mysql> use silk; drop table subnets; drop table gorp_migrations;</pre>
+    <pre class="terminal">mysql> use silk; drop table if exists subnets; drop table if exists gorp_migrations;</pre>
   1. Exit MySQL:
     <pre class="terminal">mysql> exit</pre>
   1. Exit the `mysql` VM:

--- a/backup-restore/rollback-ert-bbr.html.md.erb
+++ b/backup-restore/rollback-ert-bbr.html.md.erb
@@ -228,7 +228,7 @@ $ BOSH\_CLIENT\_SECRET=BOSH-PASSWORD \
   1. From the `mysql` VM, run the following command:
     <pre class="terminal">$ sudo /var/vcap/packages/mariadb/bin/mysql -u root -p</pre> When prompted, enter the MySQL admin password.<br><br>
   1. At the MySQL prompt, run the following command:
-    <pre class="terminal">mysql> use silk; drop table subnets; drop table gorp_migrations;</pre>
+    <pre class="terminal">mysql> use silk; drop table if exists subnets; drop table if exists gorp_migrations;</pre>
   1. Exit MySQL:
     <pre class="terminal">mysql> exit</pre>
   1. Exit the `mysql` VM:


### PR DESCRIPTION
There are circumstance under which the tables in the silk databases have no actually been created so updating `drop table` to `drop table if exists` is needed. This is not an issue in 2.0 onwards.