### PR TITLE
Update Diego BBS scaling guidelines [#154252382]

### DIFF
--- a/_pcf_scale_table.html.md.erb
+++ b/_pcf_scale_table.html.md.erb
@@ -21,9 +21,9 @@ The following table provides recommended instance counts for a high-availability
         </tr>
         <tr>
                 <td>Diego BBS</td>
-                <td>&ge; 3</td>
+                <td>&ge; 2</td>
                 <td>1</td>
-                <td>Set this to an odd number equal to or one greater than the number of AZs you have, in order to maintain quorum. Distribute the instances evenly across the AZs, at least one instance per AZ.</td>
+                <td>For high availability, use at least one per AZ, or at least two if only one AZ.</td>
         </tr>
         <tr>
                 <td>Consul</td>


### PR DESCRIPTION
This advice is applicable to ERT 1.10/1.11/1.12 and PAS 2.0 and later.

Because these versions of ERT no longer deploy an etcd cluster to the
diego_database VMs, there is no longer a requirement to maintain at least
3 nodes for quorum.