### PR TITLE
UAA token obtain fix

### DIFF
--- a/backup-restore/system-setup-bbr.html.md.erb
+++ b/backup-restore/system-setup-bbr.html.md.erb
@@ -84,7 +84,7 @@ If you have configured another machine as your jumpbox, run the following comman
   </br># Get UAA token
   $ uaac target $OPSMAN/uaa --skip-ssl-validation
   $ uaac token owner get opsman $OPSMAN_USERNAME -s "" -p $OPSMAN_PASSWORD
-  $ apitoken=uaac contexts | grep $OPSMAN -B6 | grep access_token | cut -d ':' -f 2 | cut -d ' ' -f 2
+  $ apitoken=$(uaac contexts | sed -n "/$OPSMAN/,\$p" | grep -o -P '(?<=access_token:\ ).*(?=)' | head -1)
   </br># Get the certificate (it's a json payload)
   $ export cert=$(curl -k "https://$OPSMAN/api/v0/security/root_ca_certificate" 
   -X GET 


### PR DESCRIPTION
Obtaining UAA token for pcf 1.12 hadn't worked as documented :
- It doesn't have shell execution `$(...)`
- It hadn't worked with old `grep $OPSMAN -B6` part either

Also applicable to [2.0 branch](https://github.com/pivotal-cf/docs-pcf-install/blob/2.0/backup-restore/system-setup-bbr.html.md.erb#L87) and [1.12 branch](https://github.com/pivotal-cf/docs-pcf-install/blob/1.12/backup-restore/system-setup-bbr.html.md.erb#L87)

