### PR TITLE
Changing Redis version

### DIFF
--- a/upgrading-pcf.html.md.erb
+++ b/upgrading-pcf.html.md.erb
@@ -122,13 +122,13 @@ If your PCF deployment contains **RabbitMQ for PCF**, download and upgrade Rabbi
 
 ### <a id="upgrade-redis"></a>Prep 11: Upgrade and Configure Redis for PCF
 
-If your PCF deployment contains **Redis for PCF**, download and upgrade to Redis for PCF v1.9 or later. Ensure that you complete the following as part of the upgrade:
+If your PCF deployment contains **Redis for PCF**, download and upgrade to Redis for PCF v1.10 or later. Ensure that you complete the following as part of the upgrade:
 
-* If your PCF deployment currently uses Redis v1.7 or earlier, you must set up a [service network](http://docs.pivotal.io/redis/1-9/odnetworking.html#architecture_networks) to use Redis v1.9.  
+* If your PCF deployment currently uses Redis v1.7 or earlier, you must set up a [service network](http://docs.pivotal.io/redis/1-10/odnetworking.html#architecture_networks) to use Redis v1.10.  
 * When performing the upgrade, ensure that persistent disk is set to 3.5x the amount of RAM for your Dedicated-VM Redis instances.
-* Ensure you have configured [firewall rules](http://docs.pivotal.io/redis/1-9/odnetworking.html#network-rules) on your Redis VM instances.
+* Ensure you have configured [firewall rules](http://docs.pivotal.io/redis/1-10/odnetworking.html#network-rules) on your Redis VM instances.
 
-For upgrade instructions, see the [Redis for PCF documentation](https://docs.pivotal.io/redis/1-9/index.html).
+For upgrade instructions, see the [Redis for PCF documentation](https://docs.pivotal.io/redis/1-10/index.html).
 
 ### <a id="upgrade-add-ons"></a>Prep 12: Check OS Compatibility of PCF and BOSH-Managed Add-Ons
 


### PR DESCRIPTION
Redis for PCF version 1.9 is only compatible with Ops Man 1.10 and 1.11
For PCF 1.12 we need to use Redis for PCF version 1.10

Refer to the Product Snapshot section in http://docs.pivotal.io/redis/1-9/index.html