### PR TITLE
Link to list of supported external databases for backup and restore

### DIFF
--- a/backup-restore/backup-pcf-bbr.html.md.erb
+++ b/backup-restore/backup-pcf-bbr.html.md.erb
@@ -22,8 +22,6 @@ During the backup, BBR stops the Cloud Controller API and the Cloud Controller w
     <li><strong>The restore is a destructive operation.</strong> BBR is designed to restore PCF after a disaster. If it fails, the environment may be left in an unusable state and require reprovisioning. The two restore scenarios currently documented are <a href="restore-pcf-bbr.html">Restoring Pivotal Cloud Foundry from Backup with BBR</a> and <a href="in-place-restore.html">Restoring a PAS Backup In-Place</a>.</li>
     <li><strong>The Cloud Controller API will stop sending and receiving calls</strong> for the duration of PCF restoration.</li>
     <li><strong>BBR does not back up any service data.</strong></li>
-    <li><strong>Using an external blobstore or an external MySQL database results in an unusable restore</strong> even if the restore appears to run successfully.</li>
-    <li><strong>For PCF v2.0.0, BBR only supports backup and restore of environments with zero or one CredHub instances.</strong></li>
   </ul>
 </div>
 
@@ -44,10 +42,11 @@ BBR is a binary that can back up and restore BOSH deployments and BOSH Directors
 
 BBR backs up the following PCF components:
 
-* **PAS**: PAS must be configured with an internal MySQL database and a WebDAV/NFS blobstore to be backed up and restored with BBR. BBR does not support PAS with an external blobstore or an external MySQL database.
-  <ul class="note warning"><strong>Warning</strong>: The following guidelines apply when you are using BBR to back up PCF and have configured an external blobstore and/or external database in PAS:<ul>
+* **PAS**: PAS must be configured with an internal MySQL database or a [supported external database](https://docs.cloudfoundry.org/bbr/cf-backup.html#supported-external-databases) and a WebDAV/NFS blobstore to be backed up and restored with BBR. BBR does not support PAS with an external blobstores.
+
+  <ul class="note warning"><strong>Warning</strong>: The following guidelines apply when you are using BBR to back up PCF and have configured an external blobstore and/or unsupported external database in PAS:<ul>
     <li> If you configured an internal database and an external blobstore in PAS, then follow the PCF backup process, and copy the external blobstore via the IaaS. There may be inconsistencies between the blobstore and database, which may result in some apps not coming up during a restore. Those apps can be repushed. </li>
-    <li>If you configured an external database and an external blobstore in PAS, then follow the PCF backup process, but skip the backup of PAS. Copy the external database and blobstore via the IaaS. There may be inconsistencies  between the blobstore and database, which may result in some apps not coming up during a restore. Those apps can be repushed.</li></ul></ul>
+    <li>If you configured an unsupported external database and an external blobstore in PAS, then follow the PCF backup process, but skip the backup of PAS. Copy the external database and blobstore via the IaaS. There may be inconsistencies  between the blobstore and database, which may result in some apps not coming up during a restore. Those apps can be repushed.</li></ul></ul>
 
 * **BOSH Director**: The BOSH Director must have an internal Postgres database to be backed up and restored with BBR. As part of backing up the BOSH Director, BBR backs up the BOSH UAA database and the CredHub database.
 


### PR DESCRIPTION
This adds a link to the section added in the open source PR here: https://github.com/cloudfoundry/docs-bbr/pull/18 so should only be applied after that PR.