### PR TITLE
Describe using 'om' for installation_settings import/export

### DIFF
--- a/backup-restore/backup-pcf-bbr.html.md.erb
+++ b/backup-restore/backup-pcf-bbr.html.md.erb
@@ -193,13 +193,29 @@ Pivotal recommends that you back up your Ops Manager installation settings by ex
 frequently. This option is only available after you have deployed at least one time.
 Always export your installation settings before following the steps in the [Import Installation Settings](./restore-pcf-bbr.html#import) section of the [Restoring Pivotal Cloud Foundry from Backup with BBR](./restore-pcf-bbr.html) topic.
 
-<p class="note"><strong>Note</strong>: Exporting your installation settings only backs up the settings you configured in Ops Manager. It does not back up your virtual machines (VMs) or any external MySQL databases.</p>
+<div class="note">
+  <strong>Notes</strong>:
+  <ul>
+    <li>Exporting your installation settings only backs up the settings you configured in Ops Manager. It does not back up your virtual machines (VMs) or any external MySQL databases.</li>
+    <li>Ops Manager 1.12 onwards exports installation settings only, so the output is much smaller than in previous Ops Manager versions.</li>
+  </ul>
+</div>
 
-From the **Installation Dashboard** in the Ops Manager interface, click your user name at the top right navigation. Select **Settings**.
+There are two ways to export the installation settings.
 
-<p class="note"><strong>Note</strong>: Ops Manager 1.12 exports installation settings only, so the output is much smaller than in previous Ops Manager versions.</p>
+1. If you want to do it through the Ops Manager UI:
 
-<%= image_tag("settings.png") %>
+    From the **Installation Dashboard** in the Ops Manager interface, click your user name at the top right navigation. Select **Settings**.
+
+    <%= image_tag("settings.png") %>
+
+1. If you prefer to use the command line:
+
+    You can export the Ops Manager installation settings with the [`om` tool](https://github.com/pivotal-cf/om):
+
+    ```
+    om --target OPSMAN-URL --username OPSMAN-USERNAME --password OPSMAN-PASSWORD --request-timeout 7200 export-installation --output-file om-installation-settings.zip
+    ```
 
 ### <a id='bbr-backup-director'></a> Step 8: Back Up Your BOSH Director
 

--- a/backup-restore/restore-pcf-bbr.html.md.erb
+++ b/backup-restore/restore-pcf-bbr.html.md.erb
@@ -61,27 +61,41 @@ If you recreate your IaaS resources, you must also add those resources to Ops Ma
   * [Step 3](../openstack-setup.html#create-om-image) through [Step 7](../openstack-setup.html#dns-entry) of the <em>Provisioning the OpenStack Infrastructure</em> topic.
   * [Deploying Operations Manager to vSphere](../deploying-vm.html)
 
-1. Access your new Ops Manager by navigating to `YOUR-OPS-MAN-FQDN` in a browser.
+1. Import your installation settings. This can be done in two ways:
 
-1. On the **Welcome to Ops Manager** page, click **Import Existing Installation**.
+    1. Using the Ops Manager UI
 
-    <%= image_tag("../images/upgrading/welcome.png") %>
+        1. Access your new Ops Manager by navigating to `YOUR-OPS-MAN-FQDN` in a browser.
 
-1. In the import panel, perform the following tasks:
-  * Enter your **Decryption Passphrase**.
-  * Click **Choose File** and browse to the installation zip file that you exported in the <a href='./backup-pcf-bbr.html#export'>Step 7: Export Installation Settings</a> section of the <i>Backing Up Pivotal Cloud Foundry with BBR</i> topic.
+        1. On the **Welcome to Ops Manager** page, click **Import Existing Installation**.
 
-    <%= image_tag("../images/upgrading/decryption_passphrase.png") %>
+            <%= image_tag("../images/upgrading/welcome.png") %>
 
-1. Click **Import**.
+        1. In the import panel, perform the following tasks:
+          * Enter your **Decryption Passphrase**.
+          * Click **Choose File** and browse to the installation zip file that you exported in the <a href='./backup-pcf-bbr.html#export'>Step 7: Export Installation Settings</a> section of the <i>Backing Up Pivotal Cloud Foundry with BBR</i> topic.
 
-    <p class="note"><strong>Note</strong>:
-      Some browsers do not provide feedback on the status of the import process,
-      and may appear to hang. The import process takes at least 10 minutes, and takes longer the more tiles that were present on the backed-up Ops Manager.</p>
+            <%= image_tag("../images/upgrading/decryption_passphrase.png") %>
 
-1. A **Successfully imported installation** message appears upon completion.
+        1. Click **Import**.
 
-    <%= image_tag("../images/upgrading/success.png") %>
+            <p class="note"><strong>Note</strong>:
+              Some browsers do not provide feedback on the status of the import process,
+              and may appear to hang. The import process takes at least 10 minutes, and takes longer the more tiles that were present on the backed-up Ops Manager.</p>
+
+        1. A **Successfully imported installation** message appears upon completion.
+
+            <%= image_tag("../images/upgrading/success.png") %>
+
+    1. Using the command line
+
+        You can import the Ops Manager installation settings with the [`om` tool](https://github.com/pivotal-cf/om):
+
+        ```
+        om --target OPSMAN-URL --username OPSMAN-USERNAME --password OPSMAN-PASSWORD --request-timeout 7200 import-installation  --installation om-installation-settings.zip --decryption-passphrase DECRYPTION-PASSPHRASE
+        ```
+
+        Where `om-installation-settings.zip` is the file that you exported in the <a href='./backup-pcf-bbr.html#export'>Step 7: Export Installation Settings</a> section of the <i>Backing Up Pivotal Cloud Foundry with BBR</i> topic.
 
 ## <a id="config-new-resources"></a> (Optional) Step 3: Configure Ops Manager for New Resources
 


### PR DESCRIPTION
Previously we only described the graphical way of importing/exporting installation settings from Operations Manager. We now add the option to do it via the command line.