### PR TITLE
Create blobstore gcp service account key for gcp.

### DIFF
--- a/gcp-prepare-env-terraform.html.md.erb
+++ b/gcp-prepare-env-terraform.html.md.erb
@@ -141,7 +141,8 @@ Complete this step if you want to do any of the following:
 - Change the default CIDR ranges
 - Deploy the Isolation Segment tile
 - Specify a host for the external Google Cloud SQL database
-- Use external Google Storage buckets 
+- Use external Google Storage buckets
+- Create GCP Service Account Key for Blobstore
 
 In your `terraform.tfvars` file, specify the appropriate variables from the sections below.
 
@@ -191,6 +192,14 @@ If you want to use Google Cloud Storage buckets for the PAS Cloud Controller, ad
 ```
 pas_sql_db_host = true
 ```
+
+### <a id="gcs"></a> Create GCP Service Account Key for Blobstore
+
+If you don't want to use a generated service account for blob storage, but instead would like to provide your own:
+```
+create_blobstore_service_account_key = false
+```
+
 
 ## <a id="download"></a>Step 4: Create GCP Resources with Terraform ##
 


### PR DESCRIPTION
When there is a new release of terraforming-gcp with this https://github.com/pivotal-cf/terraforming-gcp/commit/c0a71a87a7b14eca9c9ab1dbadbc556bea527466

We have modified the docs to support this new configurable property.

@evanfarrar @genevieve 