### PR TITLE
Document Backup and Restore of Versioned S3 blobstore

### DIFF
--- a/_filestore_s3_config.html.md.erb
+++ b/_filestore_s3_config.html.md.erb
@@ -13,6 +13,7 @@ To use an external S3-compatible filestore for your Pivotal Application Service 
     * For **Region**, enter the region in which your S3 buckets are located, such as `us-west-2`.
     * Select **Server-side Encryption (available for AWS S3 only)** to encrypt the contents of your S3 filestore. 
     * (Optional) If you selected **Server-side Encryption**, you can also specify a **KMS Key ID**. PAS uses the KMS key to encrypt files uploaded to the blobstore. If you do not provide a KMS Key ID, PAS uses the default AWS key. For more information, see [Protecting Data Using Server-Side Encryption with AWS KMS–Managed Keys (SSE-KMS)](https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingKMSEncryption.html). 
+    * (Optional) If your buckets have versioning enabled, select **Versioning is enabled for all buckets listed below** to enable backup and restore of your versioned S3 blobstore. Note that backup and restore of the blobstore will only work with versioned S3 V4 Signature blobstores. Non-versioned S3 compatible blobstores are not yet supported by backup and restore. For more information about how to set up versioning for your blobstore, see documentation <a href="https://docs.cloudfoundry.org/bbr/external-blobstores.html">here</a>.
     * Enter values for the remaining fields as follows:
     <table border="1" class="nice" >
       <tr>

--- a/backup-restore/backup-pcf-bbr.html.md.erb
+++ b/backup-restore/backup-pcf-bbr.html.md.erb
@@ -42,11 +42,14 @@ BBR is a binary that can back up and restore BOSH deployments and BOSH Directors
 
 BBR backs up the following PCF components:
 
-* **PAS**: PAS must be configured with either an internal MySQL database or a [supported external database](https://docs.cloudfoundry.org/bbr/cf-backup.html#supported-external-databases) plus a WebDAV/NFS blobstore. BBR does not support PAS with an external blobstore.
+* **PAS**: PAS must be configured with either an internal MySQL database or a [supported external database](https://docs.cloudfoundry.org/bbr/cf-backup.html#supported-external-databases) plus a WebDAV/NFS blobstore or versioned S3 compatible external blobstore. BBR does not support PAS with other external blobstores.
 
-  <ul class="note warning"><strong>Warning</strong>: The following guidelines apply when you are using BBR to back up PCF and have configured an external blobstore and/or unsupported external database in PAS:<ul>
-    <li> If you configured an internal database and an external blobstore in PAS, then follow the PCF backup process, and copy the external blobstore via the IaaS. There may be inconsistencies between the blobstore and database, which may result in some apps not coming up during a restore. Those apps can be repushed. </li>
-    <li>If you configured an unsupported external database and an external blobstore in PAS, then follow the PCF backup process, but skip the backup of PAS. Copy the external database and blobstore via the IaaS. There may be inconsistencies  between the blobstore and database, which may result in some apps not coming up during a restore. Those apps can be repushed.</li></ul></ul>
+  <ul class="note warning"><strong>Warning</strong>: The following guidelines apply when you are using BBR to back up PCF and have configured an unsupported external blobstore and/or unsupported external database in PAS:<ul>
+  <li> If you configured a supported database and an unsupported external blobstore in PAS, then follow the PCF backup process, and copy the external blobstore via the IaaS. 
+  <li> If you configured an unsupported external database and a supported blobstore in PAS, then follow the PCF backup process, and copy the external database via the IaaS. 
+  <li>If you configured both an unsupported external database and an unsupported external blobstore in PAS, then follow the PCF backup process, but skip the backup of PAS. Copy the external database and blobstore via the IaaS.</ul> 
+  There may be inconsistencies between the blobstore and database, which may result in some apps not coming up during a restore. Those apps can be repushed.
+  </ul>
 
 * **BOSH Director**: The BOSH Director must have an internal Postgres database to be backed up and restored with BBR. As part of backing up the BOSH Director, BBR backs up the BOSH UAA database and the CredHub database.
 
@@ -253,9 +256,7 @@ $ bbr director \
 </pre>
 ### <a id='bbr-backup'></a> Step 9: Back Up Your PAS Deployment
 
-1.  If you are using an external blobstore, create a copy of the blobstore with your IaaS specific tool. Your blobstore backup may be slightly inconsistent with your PAS backup depending on the duration of time between performing the backups.
-
-1.  If you are using an external blobstore, create a copy of the blobstore with your IaaS specific tool. Your blobstore backup may be slightly inconsistent with your PAS backup depending on the duration of time between performing the backups.
+1.  (Optional) If you are not using an internal blobstore or a versioned S3-compatible external blobstore, create a copy of the blobstore with your IaaS specific tool. Your blobstore backup may be slightly inconsistent with your PAS backup depending on the duration of time between performing the backups.
 
 1. Run the BBR backup command from your jumpbox to back up your PAS deployment:
   <pre class="terminal">

--- a/backup-restore/disaster-recovery.html.md.erb
+++ b/backup-restore/disaster-recovery.html.md.erb
@@ -108,14 +108,14 @@ Blobstores can be very large. To minimize downtime, only metadata about the blob
 The follow components and products do not yet support BBR:
 
 * **Data services**: BBR is not yet supported in Pivotal’s flagship data services (MySQL, RabbitMQ, Redis, PCC). In the meantime, operators should use the automatic backups feature of each tile, available within Ops Manager. 
-* **External blobstores**: BBR does not yet back up external blobstores but can be used to back up the rest of <%= vars.product_short %>. Pivotal recommends that operators copy the blobstore using IaaS tooling, in conjunction with backing up <%= vars.product_short %> with BBR.
-* **External databases**: BBR does not yet support <%= vars.product_short %> configured with an external database. Pivotal recommends that operators copy the database using IaaS tooling.
+* **External blobstores**: BBR only supports versioned S3-compatible external blobstores. Any other type of external blobstore is not supported by BBR, but BBR can be used to back up the rest of PAS. Pivotal recommends that operators copy incompatible blobstores using IaaS tooling, in conjunction with backing up <%= vars.product_short %> with BBR.
+* **External databases**: BBR supports a <a href="https://docs.cloudfoundry.org/bbr/cf-backup.html#supported-external-databases">defined list of external databases</a>. For external databases not supported by BBR, Pivotal recommends that operators copy the database using IaaS tooling.
 
-To address the limitations noted above, follow the guidlines below when using BBR to back up PCF when <%= vars.product_short %> configured with an external blobstore or external database:
+To address the limitations noted above, follow the guidlines below when using BBR to back up PCF when <%= vars.product_short %> configured with an unsupported external blobstore or external database:
 
-* With <%= vars.product_short %> configured with an internal database and an external blobstore, follow the PCF backup process using BBR and copy the external blobstore using your IaaS. Inconsistencies between the blobstore and database may result in apps failing to restart during the restore. You can push these apps again to restart them. 
+* With <%= vars.product_short %> configured with an internal database and an unsupported external blobstore, follow the PCF backup process using BBR and copy the external blobstore using your IaaS. Inconsistencies between the blobstore and database may result in apps failing to restart during the restore. You can push these apps again to restart them. 
 
-* With <%= vars.product_short %> configured with an external database and an external blobstore, follow the PCF backup process using BBR, but skip the backup of <%= vars.product_short %>. Copy the external database and blobstore using your IaaS. Inconsistencies between the blobstore and database may result in apps failing to restart during the restore. You can push these apps again to restart them. 
+* With <%= vars.product_short %> configured with an unsupported external database and an unsupported external blobstore, follow the PCF backup process using BBR, but skip the backup of <%= vars.product_short %>. Copy the external database and blobstore using your IaaS. Inconsistencies between the blobstore and database may result in apps failing to restart during the restore. You can push these apps again to restart them. 
 
 ### <a id="best-practices"></a> Best Practices
 

--- a/backup-restore/restore-pcf-bbr.html.md.erb
+++ b/backup-restore/restore-pcf-bbr.html.md.erb
@@ -273,7 +273,7 @@ Scanning 19 persistent disks: 19 OK, 0 missing ...
 
 <p class="note validation"><strong>Validation</strong>: If your apps must not be running after a restore run <code>bosh stop</code> on each <code>diego_cell</code> VM in the deployment.</p>
 
-1. If you use an external blobstore and copied it during the backup, restore the external blobstore with your IAAS specific tools before running PAS restore.
+1. If you use a non-versioned or non-S3-compatible external blobstore and copied it during the backup, restore the external blobstore with your IaaS specific tools before running PAS restore.
 
 1. Run the BBR restore command from your jumpbox to restore PAS:
 <pre class="terminal">


### PR DESCRIPTION
Hi!

We added support for backing up and restoring PAS 2.1 with versioned s3 blobstore. Here is the docs update :)

Thanks,
@MirahImage && Chunyi