### PR TITLE
Remove incorrect information about uaa backup in backing up PCF doc

### DIFF
--- a/backup-restore/backup-pcf-bbr.html.md.erb
+++ b/backup-restore/backup-pcf-bbr.html.md.erb
@@ -282,7 +282,6 @@ $ bbr director \
   <ul>
     <li>Backing up PAS takes at least 10 minutes and can take considerably longer with larger blobstores or slow network connections. The backup also incurs around 10 minutes of Cloud Controller downtime during which users are unable to push, scale, or delete apps. Your apps will not be affected.</li>
     <li>Because the BBR backup command can take a long time to complete, Pivotal recommends you run it independently of the SSH session, so that the process can continue running even if your connection to the jumpbox fails. The command above uses <code>nohup</code> but you could also run the command in a <code>screen</code> or <code>tmux</code> session.</li>
-    <li>The backup artifact will contain one or more empty UAA tar files. This is an extraneous artifact. The UAA backup is included in the MySQL backup.</li>
   </ul>
 </div>
 


### PR DESCRIPTION
Remove incorrect information about uaa backup in backing up PCF doc 2.0.