### PR TITLE
Clarify that 1.12 always required 1.10.x or later

### DIFF
--- a/upgrading-pcf.html.md.erb
+++ b/upgrading-pcf.html.md.erb
@@ -113,7 +113,7 @@ This is the same information you entered at the end of deploying [Ops Manager on
 
 ### <a id="upgrade-mysql"></a>Prep 9: Upgrade MySQL for PCF
 
-If your PCF deployment includes both <b><a href="../windows/index.html">PCF Runtime for Windows</a></b> and <b>MySQL for PCF v1.x</b>, download and upgrade to MySQL for PCF v1.10.3 or later. For instructions on how to upgrade MySQL for PCF, see the 
+If your PCF deployment includes MySQL for PCF v1.x, download and upgrade to MySQL for PCF v1.10.3 or later. For instructions on how to upgrade MySQL for PCF, see the 
  <a href="http://docs.pivotal.io/p-mysql/1-10/index.html">MySQL for PCF</a> documentation.
 
 ### <a id="upgrade-rmq"></a>Prep 10: Upgrade and Configure RabbitMQ for PCF


### PR DESCRIPTION
PCF 1.12 requires Mysql 1.10.x regardless if windows tile is installed or not. In 1.12 etcd is removed and MYSQL versions lower then 1.10.x will not work without etcd  CC: @menicosia 