### PR TITLE
Update BBR supported components section

### DIFF
--- a/backup-restore/backup-pcf-bbr.html.md.erb
+++ b/backup-restore/backup-pcf-bbr.html.md.erb
@@ -49,7 +49,7 @@ BBR backs up the following PCF components:
     <li> If you configured an internal database and an external blobstore in PAS, then follow the PCF backup process, and copy the external blobstore via the IaaS. There may be inconsistencies between the blobstore and database, which may result in some apps not coming up during a restore. Those apps can be repushed. </li>
     <li>If you configured an external database and an external blobstore in PAS, then follow the PCF backup process, but skip the backup of PAS. Copy the external database and blobstore via the IaaS. There may be inconsistencies  between the blobstore and database, which may result in some apps not coming up during a restore. Those apps can be repushed.</li></ul></ul>
 
-* **BOSH Director**: The BOSH Director must have an internal Postgres database to be backed up and restored with BBR. As part of backing up the BOSH Director, BBR backs up the BOSH UAA database and the CredHub database.
+* **BOSH Director**: The BOSH Director must have an internal Postgres database and an internal blobstore to be backed up and restored with BBR. As part of backing up the BOSH Director, BBR backs up the BOSH UAA database and the CredHub database.
 
 ### Backing Up Services
 


### PR DESCRIPTION
Specify that BBR only supports internal blobstores for BOSH directors.

/cc @alamages 