### PR TITLE
Clarifying how to retrieve self-signed NSX CA Cert

### DIFF
--- a/vsphere-config.html.md.erb
+++ b/vsphere-config.html.md.erb
@@ -79,7 +79,7 @@ See [Installing Runtimes](runtimes.html) for more information about Pivotal Clou
     * **NSX Username**: The username to connect to the NSX manager.
     * **NSX Password**: The password for the username specified above.
     * **NSX CA Cert**: A CA certificate in PEM format that authenticates to the NSX server.
-    Provide the fully qualified domain name if the NSX Manager uses a self-signed SSL certificate.
+    If the NSX Manager generated a self-signed certificate, you can retrieve the CA certificate using OpenSSL with the command `openssl s_client -host <NSX Address> -port 443 -prexit -showcerts`.
     <p class="note"><strong>Note</strong>: To update NSX security group and load balancer information, see the <a href="update-nsx.html">Updating NSX Security Group and Load Balancer Information</a> topic.</p>
 
 1. Click **Save**.


### PR DESCRIPTION
The docs originally mentioned that you could provide the fully-qualified domain name for the NSX manager in this field if it was a self-signed certificate, but this doesn't work.  It wasn't clear how to retrieve this CA cert if you allowed NSX to generate its own certs during installation, so I've added an example command.