### PR TITLE
GCP External Database is Optional.

### DIFF
--- a/gcp-prepare-env-terraform.html.md.erb
+++ b/gcp-prepare-env-terraform.html.md.erb
@@ -140,7 +140,7 @@ Complete this step if you want to do any of the following:
 
 - Change the default CIDR ranges
 - Deploy the Isolation Segment tile
-- Specify a host for the external Google Cloud SQL database
+- Use an external Google Cloud SQL database
 - Use external Google Storage buckets
 - Disable generated GCP service account key for blobstore
 
@@ -177,6 +177,12 @@ ISO_SEG_SSL_KEY
 ```
 
 ### <a id="cloudsql"></a> External Database
+
+1. If you want to use an external Google Cloud SQL database for Ops Manager and Pivotal Application Service (PAS), add the following to your `terraform.tfvars` file:
+
+    ```
+    external_database = true
+    ```
 
 1. If you want to specify a single host from which users can connect to the Ops Manager and runtime database, add the following variables to your `terraform.tfvars` file. Replace `HOST_IP_ADDRESS` with your desired IP addresses.
 


### PR DESCRIPTION
Move GCP External Database back to an optional parameter in gcp installation.