### PR TITLE
AWS OM Private Key is marked as sensitive.

### DIFF
--- a/aws-om-config-terraform.html.md.erb
+++ b/aws-om-config-terraform.html.md.erb
@@ -72,7 +72,8 @@ Use the `ops_manager_dns` value from running `terraform output`.
 1. Complete the remainder of the **AWS Management Console Config** page with the following information.
     * **Security Group ID**: Enter the value of `vms_security_group_id` from the Terraform output.
     * **Key Pair Name**: Enter the value of `ops_manager_ssh_public_key_name` from the Terraform output.
-    * **SSH Private Key**: Enter the value of `ops_manager_ssh_private_key` from the Terraform output.
+    * **SSH Private Key**: Enter the value of `ops_manager_ssh_private_key` from running `terraform output`.
+    This output is sensitive so it will not be printed as a result of `terraform apply`.
     * **Region**: Select the region where you deployed Ops Manager.
     * **Encrypt EBS Volumes**: Select this checkbox to enable full encryption
       on persistent disks of all BOSH-deployed virtual machines (VMs), except


### PR DESCRIPTION
Remind users to run `terraform output` in order to get that value.
https://github.com/pivotal-cf/terraforming-aws/issues/44