### PR TITLE
The subnet has been created as pas

### DIFF
--- a/gcp-prepare-env.html.md.erb
+++ b/gcp-prepare-env.html.md.erb
@@ -556,7 +556,7 @@ If you are deploying **PAS or other runtimes**, proceed to the following step.
     Example: For region `us-west1`, select zone `us-west1-a`.
   * Under **Group type**, select **Unmanaged instance group**. 
   * For **Network**, select `MY-PCF-virt-net`. 
-  * For **Subnetwork**, select the `MY-PCF-subnet-ert-MY-GCP-REGION` subnet that you created previously.  
+  * For **Subnetwork**, select the `MY-PCF-subnet-pas-MY-GCP-REGION` subnet that you created previously.  
   * Click **Create**. 
 1. Create a second instance group with the following details:
   * **Name**: `MY-PCF-http-lb`
@@ -565,7 +565,7 @@ If you are deploying **PAS or other runtimes**, proceed to the following step.
     Example: For region `us-west1`, select zone `us-west1-b`.
   * **Group type**: Select **Unmanaged instance group**. 
   * **Network**: Select `MY-PCF-virt-net`. 
-  * **Subnetwork**: Select the `MY-PCF-subnet-ert-MY-GCP-REGION` subnet that you created previously.  
+  * **Subnetwork**: Select the `MY-PCF-subnet-pas-MY-GCP-REGION` subnet that you created previously.  
 1. Create a third instance group with the following details:
   * **Name**: `MY-PCF-http-lb`
   * **Location**: **Single-zone**
@@ -573,7 +573,7 @@ If you are deploying **PAS or other runtimes**, proceed to the following step.
     Example: For region `us-west1`, select zone `us-west1-c`.
   * **Group type**: Select **Unmanaged instance group**. 
   * **Network**: Select `MY-PCF-virt-net`. 
-  * **Subnetwork**: Select the `MY-PCF-subnet-ert-MY-GCP-REGION` subnet that you created previously.  
+  * **Subnetwork**: Select the `MY-PCF-subnet-pas-MY-GCP-REGION` subnet that you created previously.  
 
 ### <a id='create-health-check'></a> Create Health Check
 


### PR DESCRIPTION
To coincide with the changes in product names, earlier in these instructions we created the network named pas not ert.