### PR TITLE
Update _stopping_cc_boshv2.html.md.erb

### DIFF
--- a/backup-restore/_stopping_cc_boshv2.html.md.erb
+++ b/backup-restore/_stopping_cc_boshv2.html.md.erb
@@ -23,7 +23,7 @@
         <pre class="terminal">$ bosh -e DIRECTOR\_IP -d DEPLOYMENT-NAME ssh JOB-NAME</pre>
         For example:
         <pre class="terminal">$ bosh -e DIRECTOR\_IP -d DEPLOYMENT-NAME ssh cloud\_controller</pre>
-    1. From the VM, list the running processes:
+    1. From the VM, list the running processes:(Monit needs Sudo access, please use "Sudo su -" to view/start/stop monit process)
         <pre class="terminal">$ monit summary</pre>
     1. Start all processes that start with `cloud_controller_`:
         <pre class="terminal">$ monit start PROCESS-NAME</pre>


### PR DESCRIPTION
After SSh into cloud controller VM, monit command is not working until we grant ourselves access by "sudo su -".  After some troubleshooting following docs from Backup, it is validated by using the process listed from https://docs.cloudfoundry.org/running/troubleshooting.html.