### PR TITLE
Subnet CIDRs specified in the doc do not match the subnet CIDRs in Terraform

### DIFF
--- a/azure-om-config-terraform.html.md.erb
+++ b/azure-om-config-terraform.html.md.erb
@@ -161,10 +161,10 @@ Select **Create Networks** and follow the procedures in this section to add the 
 1. Under **Subnets**, complete the following fields:
    * **Azure Network Name**: Enter `NETWORK-NAME/SUBNET-NAME`, where `NETWORK-NAME` is the `network_name` output from Terraform and `SUBNET-NAME` is the `management_subnet_name` output from Terraform.
      <p class="note"><strong>Note</strong>: The Azure portal sometimes displays the names of resources with incorrect capitalization. Always use the Azure CLI to retrieve the correctly capitalized name of a resource.</p>
-   * **CIDR**: Enter `10.0.4.0/22`.
-   * **Reserved IP Ranges**: Enter the first 9 IP addresses of the subnet. For example, `10.0.4.1-10.0.4.9`.
+   * **CIDR**: Enter the CIDR listed under `management_subnet_cidrs` output from Terraform. For example, `10.0.8.0/26`.
+   * **Reserved IP Ranges**: Enter the first 9 IP addresses of the subnet. For example, `10.0.8.1-10.0.8.9`.
    * **DNS**: Enter `168.63.129.16`.
-   * **Gateway**: Enter the first IP address of the subnet. For example, `10.0.4.1`.
+   * **Gateway**: Enter the first IP address of the subnet. For example, `10.0.8.1`.
      <%= image_tag("azure/create-networks-management.png") %>
 1. Click **Save**.<%= vars.expand_network_azs %>
 
@@ -175,10 +175,10 @@ Select **Create Networks** and follow the procedures in this section to add the 
 1. For **Name**, enter the name of the network you want to create. For example, `Deployment`.
 1. Under **Subnets**, complete the following fields:
    * **Azure Network Name**: Enter `NETWORK-NAME/SUBNET-NAME`, where `NETWORK-NAME` is the `network_name` output from Terraform and `SUBNET-NAME` is the `pas_subnet_name` output from Terraform.
-   * **CIDR**: Enter `10.0.12.0/22`.
-   * **Reserved IP Ranges**: Enter the first 9 IP addresses of the subnet. For example, `10.0.12.1-10.0.12.9`.
+   * **CIDR**: Enter the CIDR listed under `pas_subnet_cidrs` output from Terraform. For example, `10.0.0.0/22`.
+   * **Reserved IP Ranges**: Enter the first 9 IP addresses of the subnet. For example, `10.0.0.1-10.0.0.9`.
    * **DNS**: Enter `168.63.129.16`.
-   * **Gateway**: Enter the first IP address of the subnet. For example, `10.0.12.1`.
+   * **Gateway**: Enter the first IP address of the subnet. For example, `10.0.0.1`.
      <%= image_tag("azure/create-networks-deployment.png") %>
 1. Click **Save**.
 
@@ -188,10 +188,10 @@ Select **Create Networks** and follow the procedures in this section to add the 
 1. For **Name**, enter the name of the network you want to create. For example, `Services`.
 1. Under **Subnets**, complete the following fields:
    * **Azure Network Name**: Enter `NETWORK-NAME/SUBNET-NAME`, where `NETWORK-NAME` is the `network_name` output from Terraform and `SUBNET-NAME` is the `services_subnet_name` output from Terraform.
-   * **CIDR**: Enter `10.0.8.0/22`.
-   * **Reserved IP Ranges**: Enter the first 9 IP addresses of the subnet. For example, `10.0.8.1-10.0.8.9`.
+   * **CIDR**: Enter the CIDR listed under `services_subnet_cidrs` output from Terraform. For example, `10.0.4.0/22`.
+   * **Reserved IP Ranges**: Enter the first 9 IP addresses of the subnet. For example, `10.0.4.1-10.0.4.9`.
    * **DNS**: Enter `168.63.129.16`.
-   * **Gateway**: Enter the first IP address of the subnet. For example, `10.0.8.1`.
+   * **Gateway**: Enter the first IP address of the subnet. For example, `10.0.4.1`.
      <%= image_tag("azure/create-networks-services.png") %>
 1. Click **Save**. If you do not have **Enable ICMP checks** selected, you may see red warnings which you can safely ignore.
 


### PR DESCRIPTION
Subnet CIDRs specified in the doc do not match the subnet CIDRs in Terraform templates. 

The CIDRs should be: 

management_subnet_cidrs=10.0.8.0/26
pas_subnet_cidrs=10.0.0.0/22
services_subnet_cidrs=10.0.4.0/22

In any case rather than specify the actual CIDRs in the doc, it should reference Terraform output variables that will carry the subnet CIDRs.