### PR TITLE
AWS Management Console Configuration Correction

### DIFF
--- a/aws-om-config-terraform.html.md.erb
+++ b/aws-om-config-terraform.html.md.erb
@@ -69,7 +69,6 @@ Use the `ops_manager_dns` value from running `terraform output`.
       Identity and Access Management (IAM) profile.
 
 1. Complete the remainder of the **AWS Management Console Config** page with the following information.
-    * **VPC ID**: Enter the value of `vpc_id` from the Terraform output.
     * **Security Group ID**: Enter the value of `vms_security_group_id` from the Terraform output.
     * **Key Pair Name**: Enter the value of `ops_manager_ssh_public_key_name` from the Terraform output.
     * **SSH Private Key**: Run `terraform output` to view the value of `ops_manager_ssh_private_key`	and enter it into this field. `ops_manager_ssh_private_key` is a `sensitive` value and does not display when you run `terraform apply`.


### PR DESCRIPTION
There is no such step in the latest version of Ops Manager to enter "vpc-id".