### PR TITLE
Corrected Terraform output attribute names

### DIFF
--- a/aws-om-config-terraform.html.md.erb
+++ b/aws-om-config-terraform.html.md.erb
@@ -134,8 +134,8 @@ Manager Resurrector functionality and increase Pivotal Application Service (PAS)
     the Ops Manager **S3 Endpoint** field. For example, in the **us-west-2** region, enter `https://s3-us-west-2.amazonaws.com` into the field.
     1. Complete the following fields:
         * **Bucket Name**: Enter the value of `ops_manager_bucket` from the Terraform output.
-        * **Access Key ID**: Enter the value of `iam_user_access_key` from the Terraform output.
-        * **AWS Secret Key**: Enter the value of `iam_user_secret_access_key` from the Terraform output.
+        * **Access Key ID**: Enter the value of `ops_manager_iam_user_access_key` from the Terraform output.
+        * **AWS Secret Key**: Enter the value of `ops_manager_iam_user_secret_access_key` from the Terraform output.
     1. Select **V2 Signature** or **V4 Signature**. If you select **V4 Signature**, enter your **Region**.
     <p class="note"><strong>Note</strong>: AWS recommends using Signature Version 4 when possible. For more information about AWS S3 Signatures, see the AWS <a href="http://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-authenticating-requests.html">Authenticating Requests</a> documentation.</p>
 


### PR DESCRIPTION
The Terraform output file does not have any output attribute names "iam_user_access_key" or "iam_user_secret_key". I corrected them.