### PR TITLE
haproxy tls forward ca cert note to include referenced CA api endpoint

### DIFF
--- a/_haproxy_router_tls_forward.html.md.erb
+++ b/_haproxy_router_tls_forward.html.md.erb
@@ -19,7 +19,7 @@ Under **HAProxy forwards requests to Router over TLS**, select **Enable** or **D
       <td>
         <ol>
           <li>Leave <strong>Enable</strong> selected.</li>
-          <li>In the <strong>Certificate Authority for HAProxy Backend</strong> field, specify the Certificate Authority (CA) that signed the certificate you configured in the <strong>Certificate and Private Key for HAProxy and Router</strong> field.<p class="note"><strong>Note</strong>: If you used the <strong>Generate RSA Certificate</strong> link to generate a self-signed certificate, then the CA to specify is the Ops Manager CA, which you can locate at the CA endpoint in the Ops Manager API.</p></li>
+          <li>In the <strong>Certificate Authority for HAProxy Backend</strong> field, specify the Certificate Authority (CA) that signed the certificate you configured in the <strong>Certificate and Private Key for HAProxy and Router</strong> field.<p class="note"><strong>Note</strong>: If you used the <strong>Generate RSA Certificate</strong> link to generate a self-signed certificate, then the CA to specify is the Ops Manager CA, which you can locate at the `/api/v0/certificate_authorities` endpoint in the Ops Manager API.</p></li>
           <li>Make sure that Gorouter and HAPRoxy have TLS cipher suites in common in the <strong>TLS Cipher Suites for Router</strong> and <strong>TLS Cipher Suites for HAProxy</strong> fields.</li>
         </ol>
       </td>


### PR DESCRIPTION

a similar note was found here and it helps the user locate the required CA cert quickly 
 https://docs-pcf-staging.cfapps.io/pivotalcf/2-2/adminguide/securing-traffic.html#lb-and-router

recommend also adding a ref for `/api/v0/certificate_authorities` in the install guide note.