### PR TITLE
Documentation Fixes for PCF GCP Terraform Deployment

### DIFF
--- a/_download-stemcell.html.md.erb
+++ b/_download-stemcell.html.md.erb
@@ -1,10 +1,11 @@
 This step is only required if your Ops Manager does not already have the stemcell version required by PAS. For more information on importing stemcells, see [Importing and Managing Stemcells](../opsguide/managing-stemcells.html).
 
-1. Log into the [Pivotal Network](https://network.pivotal.io/products/pivotal-cf) and click on **Stemcells**.
+1. Open the [Stemcell product page](https://network.pivotal.io/products/stemcells) in the Pivotal Network.
+_Note, you may have to log in._
 
 1. Download the appropriate stemcell version targeted for your IaaS.
 
-1. Navigate to **Manage Stemcells** in the **Installation Dashboard**.
+1. Navigate to **Stemcell Library** in the **Installation Dashboard**.
 
 1. Click **Import Stemcell** to import the downloaded stemcell <code>.tgz</code> file.
 

--- a/gcp-er-config-terraform.html.md.erb
+++ b/gcp-er-config-terraform.html.md.erb
@@ -267,6 +267,8 @@ the cf CLI tool. See <a href="../adminguide/cli-user-management.html">Creating a
 
 ## <a id='config-lb'></a>Step 24: Configure Load Balancers ##
 
+1. Click **Resource Config**
+
 1. Under the **LOAD BALANCERS** column of the **Router** row, enter a comma-delimited list consisting of the values of `ws_router_pool` and `http_lb_backend_name` from your Terraform output. For example, `tcp:pcf-cf-ws,http:pcf-httpslb`. These are the names of the TCP WebSockets and HTTP(S) load balancers for your deployment. 
 
     <p class="note"><strong>Note</strong>: Do not add a space between key/value pairs in the <code>LOAD BALANCER</code> field or it will fail.</p>

--- a/gcp-prepare-env-terraform.html.md.erb
+++ b/gcp-prepare-env-terraform.html.md.erb
@@ -23,6 +23,7 @@ In addition to fulfilling the prerequisites listed in the [Installing Pivotal Cl
   * [Cloud Resource Manager](https://console.developers.google.com/apis/api/cloudresourcemanager.googleapis.com/)
   * [Cloud DNS](https://console.developers.google.com/apis/api/dns/overview)
   * [Cloud SQL API](https://console.developers.google.com/apis/api/sqladmin/overview)
+  * [Compute Engine API](https://console.developers.google.com/apis/api/compute/overview)
 
  To avoid this upgrade issue, ensure that </code>
 
@@ -86,6 +87,7 @@ Before you can run Terraform commands to create infrastructure resources, you mu
     service_account_key = <<SERVICE_ACCOUNT_KEY
     YOUR-KEY-JSON
     SERVICE_ACCOUNT_KEY
+    
     ```
 
 1. Edit the values in the file according to the table below:


### PR DESCRIPTION
1. Fixed Stemcells products link and corrected navigation link for Stemcell Library.
2. Added top level navigation link instruction for load balancer step.
3. Added missing Compute Engine API prerequisite.
4. Added newline after closing SERVICE_ACCOUNT_KEY heredoc to fix Terraform syntax error.