### PR TITLE
Added switch for disk size for managed disk

### DIFF
--- a/azure-om-deploy.html.md.erb
+++ b/azure-om-deploy.html.md.erb
@@ -439,6 +439,7 @@ Azure for PCF uses multiple general-purpose Azure storage accounts. The BOSH and
             --name opsman-image-2.0.x \
             --source https://$STORAGE\_NAME.blob.core.windows.net/opsmanager/image-2.0.x.vhd \
             --location $LOCATION \
+            --os-disk-size-gb 128 \
             --os-type Linux
             </pre>
             If you are using Azure China, Azure Government Cloud, or Azure Germany, replace `blob.core.windows.net` with the following:


### PR DESCRIPTION
Default size for managed disk is less than 50 gigs. @mxplusb