### PR TITLE
Move GDPR message to Backup and Restore main page

### DIFF
--- a/backup-restore/backup-pcf-bbr.html.md.erb
+++ b/backup-restore/backup-pcf-bbr.html.md.erb
@@ -315,8 +315,6 @@ If the commands complete successfully, complete the following steps:
 1. Make redundant copies of your backup and store them in multiple locations to minimize the risk of losing backups in the event of a disaster.
 1. Attempt to test restore on every backup to validate it. Perform the procedures in the next step. See [Step 11: Validate Your Backup](#validate-backup).
 
-<p class="note"><strong>Note</strong>: Backup artifacts may contain data covered by the <a href="#gdpr">European Union's <em>General Data Protection Regulation (GDPR)</em></a>.</p>
-
 ### <a id='validate-backup'></a> Step 11: (Optional) Validate Your Backup
 
 If you want to validate your backup, follow the instructions that correspond to your use case:

--- a/backup-restore/index.html.md.erb
+++ b/backup-restore/index.html.md.erb
@@ -26,6 +26,14 @@ To perform a backup of your PCF deployment manually, see <a href="backup-pcf.htm
 
 To restore your PCF deployment manually, see <a href="restore-pcf.html" class="subnav">Restoring Pivotal Cloud Foundry from Backup Manually</a>.
 
+<strong><a id='gdpr'></a>General Data Protection Regulation</strong>
+
+The General Data Protection Regulation (GDPR) came into effect on May 25, 2018 and impacts any company processing the data of EU citizens or residents, even if the company is not EU-based. 
+The GDPR sets forth how companies should handle privacy issues, securely store data, and respond to security breaches.
+
+Backup artifacts may contain personal data covered by GDPR. For example, a backup of a PAS could contain a user email. For further information regarding personal data that may be stored in PCF, 
+see <a href="https://docs.pivotal.io/pivotalcf/2-2/opsguide/gdpr.html">here</a>.
+
 ## <a id='bbr'></a>Backup and Restore with BBR 
 
 BOSH Backup and Restore (BBR) is a command-line tool for backing up and restoring BOSH deployments.


### PR DESCRIPTION
Update wording to comply with legal requirements

We are linking to the not-yet-live GDPR page that currently only exists in the PCF 2.2 docs. This should not be merged until this is back-ported to this version of the docs (in which case the link should be updated) or the PCF 2.2 docs are live. 

Paired with @ChunyiLyu 