### PR TITLE
Document reduced bbr downtime

### DIFF
--- a/backup-restore/disaster-recovery.html.md.erb
+++ b/backup-restore/disaster-recovery.html.md.erb
@@ -56,38 +56,37 @@ In a consistent backup, the blobs in the blobstore match the blobs in the Cloud 
 ### <a id="backup-timings"></a> Backup Timings
 The table below gives an indication of the downtime that you can expect. Actual downtime varies based on hardware and PCF configuration.
 
-These example timings were taken on GCP. The components scaled were CAPI workers, CredHub, UAA, Router, CAPI API, and Networking to simulate a "normal" and "very large" PCF deployment. API downtime is the sum of the time spent in lock, backup, and unlock phases. 
+These example timings were taken with PAS deployed on GCP with all components scaled to 1 and only 1 app pushed. API downtime is the sum of the time spent in lock, backup, and unlock phases.
+Backup time is significantly influenced by the size and type of blobstore configured. 
+
 <table>
   <tr>
-    <th colspan="4"><em>Backup Timings with Scaled Components</em></th>
+    <th colspan="5"><em>Backup Timings</em></th>
   </tr>
   <tr>
-    <td></td>
-   <td><em>Backup phase</em></td>
-    <td><em>Components scaled to 3</em></td>
-    <td><em>Components scaled to 6</em></td>
+    <td colspan="2"><em>Blobstore Type</em></td>
+    <td>External Versioned S3-Compatible Blobstore</td>
+    <td>Internal Blobstore</td>
   </tr>
   <tr>
     <td rowspan="3">API unavailable</td>
     <td>lock</td>
-    <td>9 minutes</td>
-    <td>21 minutes</td>
+    <td colspan="2" align="center">15 seconds</td>
   </tr>
   <tr>
     <td>backup</td>
-    <td>&lt;1 minute</td>
-    <td>&lt;1 minute</td>
+    <td>&lt;30 seconds</td>
+    <td>10 seconds</td>
   </tr>
   <tr>
     <td>unlock</td>
-    <td>9 minutes</td>
-    <td>20 minutes</td>
+    <td colspan="2" align="center">3 minutes</td>
   </tr>
   <tr>
     <td></td>
     <td>drain and checksum</td>
-    <td>80 minutes</td>
-    <td>80 minutes</td>
+    <td>&lt;10 seconds</td>
+    <td>Proportional to blobstore size</td>
   </tr>
 </table>
 


### PR DESCRIPTION
Hi,

We've updated our documents to reflect the reduced downtime
when using newer versions of bbr and the backup-and-restore-sdk.
We have also documented the effects of blobstore type and size on
backup lock and drain times.

Best,
Mirah 😺