### PR TITLE
fix aws permissions guidelines link in install guide

### DIFF
--- a/pcf-aws-manual-config.html.md.erb
+++ b/pcf-aws-manual-config.html.md.erb
@@ -516,7 +516,7 @@ To launch an Amazon Machine Image (AMI) for Ops Manager, do the following:
     * **Network**: Select the VPC that you created.
     * **Subnet**: Select `pcf-public-subnet-az0`.
     * **Auto-assign for Public IP**: Select **Enable**.
-    * **IAM role**: Select the IAM role associated with your pcf-user profile. If you have not created one, click **Create new IAM role** and follow the [Guidelines for Creating User Roles on AWS](http://docs.pivotal.io/pivotalcf/1-11/customizing/aws-iaas-user-roles.html).
+    * **IAM role**: Select the IAM role associated with your pcf-user profile. If you have not created one, click **Create new IAM role** and follow the [Guidelines for Creating User Roles on AWS](http://docs.pivotal.io/pivotalcf/2-2/customizing/aws-iaas-user-roles.html).
     * For all other fields, accept the default values.
 
     <%= image_tag("pcfaws/pcf_aws_configure_instance.png") %>


### PR DESCRIPTION

Guidelines for Creating User Roles on AWS link was pointed to old 1.11 docs and returns a 404.  Change to 2.2

related to 
https://pivotal.slack.com/archives/CAXDHBDDX/p1528993401000807