### PR TITLE
Remove Prep 12 from upgrade instructions

### DIFF
--- a/upgrading-pcf.html.md.erb
+++ b/upgrading-pcf.html.md.erb
@@ -167,10 +167,6 @@ For more information, see [Viewing Logs in the Command Line Interface](../devgui
     Exited with 0.
     </pre>
 
-### <a id="check-s3-backup-addon"></a> Prep 12: Check S3 Backups Add-On
-
-If you have enabled external blobstore backups using the S3 backups add-on, you need to update your runtime configuration when upgrading to PCF v2.1. Remove `s3-versioned-blobstore-backup-restorer` from your runtime configuration before upgrading.
-
 ## <a id="upgrade_ops"></a> Upgrade Ops Manager and Installed Products to v2.0
 
 ### <a id="export"></a> Step 1: Export Your Ops Manager


### PR DESCRIPTION
This is only required for 2.1+

paired with @jamesjoshuahill 