### PR TITLE
Include: S3 bucket unique naming reqs

### DIFF
--- a/pcf-aws-manual-config.html.md.erb
+++ b/pcf-aws-manual-config.html.md.erb
@@ -36,7 +36,7 @@ You can check the limits on your account by visiting the EC2 Dashboard on the AW
   * For **Region**, select your region.
   * Click **Next** three times.
   * Click **Create bucket**.
-  * Repeat the above steps to create four more S3 buckets: `ID-STRINGpcf-buildpacks-bucket`, `ID-STRINGpcf-packages-bucket`, `ID-STRINGpcf-resources-bucket`, and `ID-STRINGpcf-droplets-bucket`.
+  * Repeat the above steps to create four more S3 buckets: `ID-STRING-pcf-buildpacks-bucket`, `ID-STRING-pcf-packages-bucket`, `ID-STRING-pcf-resources-bucket`, and `ID-STRING-pcf-droplets-bucket`.
 
 
 ## <a id='create-iam'></a> Step 3: Create an IAM User for PCF

--- a/pcf-aws-manual-config.html.md.erb
+++ b/pcf-aws-manual-config.html.md.erb
@@ -29,9 +29,11 @@ You can check the limits on your account by visiting the EC2 Dashboard on the AW
 
 1. Navigate to the S3 Dashboard.
 
+**Note** S3 bucket names must be globally unique. So, when naming the buckets below, it is recommended to prefix the names with a common variable that ensures uniqueness (i.e. somevariable-pcf-ops-manager-bucket, somevariable-pcf-buildpacks-bucket, & so on). Then, wherever the generic names occur, you will replace them with your unique ones (like in IAM policies).
+
 1. Perform the following steps to create five S3 buckets:
   * Click **Create Bucket**
-  * For **Bucket name**, enter `pcf-ops-manager-bucket`.
+  * For **Bucket name**, enter `pcf-ops-manager-bucket`. 
   * For **Region**, select your region.
   * Click **Next** three times.
   * Click **Create bucket**.

--- a/pcf-aws-manual-config.html.md.erb
+++ b/pcf-aws-manual-config.html.md.erb
@@ -28,16 +28,15 @@ You can check the limits on your account by visiting the EC2 Dashboard on the AW
 ## <a id='create-s3'></a> Step 2: Create S3 Buckets
 
 1. Navigate to the S3 Dashboard.
-
-**Note** S3 bucket names must be globally unique. So, when naming the buckets below, it is recommended to prefix the names with a common variable that ensures uniqueness (i.e. somevariable-pcf-ops-manager-bucket, somevariable-pcf-buildpacks-bucket, & so on). Then, wherever the generic names occur, you will replace them with your unique ones (like in IAM policies).
+	<p class="note"><strong>Note:</strong>S3 bucket names must be globally unique. When naming buckets, Pivotal recommends that you prefix the generic names below with an unique and helpfully identifiable string (i.e. ID-STRING-pcf-ops-manager-bucket, MY-IDENTIFIER-pcf-buildpacks-bucket, and so on). Then you should use the same prefix when naming other associated resources, such as IAM policies.</p>
 
 1. Perform the following steps to create five S3 buckets:
   * Click **Create Bucket**
-  * For **Bucket name**, enter `pcf-ops-manager-bucket`. 
+  * For **Bucket name**, enter `ID-STRING-pcf-ops-manager-bucket`. 
   * For **Region**, select your region.
   * Click **Next** three times.
   * Click **Create bucket**.
-  * Repeat the above steps to create four more S3 buckets: `pcf-buildpacks-bucket`, `pcf-packages-bucket`, `pcf-resources-bucket`, and `pcf-droplets-bucket`.
+  * Repeat the above steps to create four more S3 buckets: `ID-STRINGpcf-buildpacks-bucket`, `ID-STRINGpcf-packages-bucket`, `ID-STRINGpcf-resources-bucket`, and `ID-STRINGpcf-droplets-bucket`.
 
 
 ## <a id='create-iam'></a> Step 3: Create an IAM User for PCF

--- a/policy-doc.html.md.erb
+++ b/policy-doc.html.md.erb
@@ -9,6 +9,8 @@ Use this policy document to complete [Step 3: Create an IAM User for PCF](./pcf-
 
 ## <a id="policy-code"></a> The Policy Document Base Code
 
+**IMPORTANT** For the S3 Bucket policy sections, make sure to update the generic bucket naming with your custom/unique bucket names. 
+
 From the AWS Management Console, copy and paste the following text in the **Policy Document** field.
 
 You may want to consider adding more policies to enable additional features. See [Add Additional AWS Policies](#add-policies) below.


### PR DESCRIPTION
Reference Issue: #369

The S3 documentation needs to be updated to include the unique naming requirements for AWS.