### PR TITLE
move `--os-disk-size-gb` to correct invocation

### DIFF
--- a/azure-om-deploy.html.md.erb
+++ b/azure-om-deploy.html.md.erb
@@ -413,7 +413,6 @@ Azure for PCF uses multiple general-purpose Azure storage accounts. The BOSH and
             --name opsman-image-2.0.x \
             --source https://$STORAGE\_NAME.blob.core.windows.net/opsmanager/image-2.0.x.vhd \
             --location $LOCATION \
-            --os-disk-size-gb 128 \
             --os-type Linux
             </pre>
             If you are using Azure China, Azure Government Cloud, or Azure Germany, replace `blob.core.windows.net` with the following:
@@ -426,6 +425,7 @@ Azure for PCF uses multiple general-purpose Azure storage accounts. The BOSH and
              --location $LOCATION \
              --nics opsman-nic \
              --image opsman-image-2.0.x \
+             --os-disk-size-gb 128 \
              --os-disk-name opsman-2.0.x-osdisk \
              --admin-username ubuntu \
              --size Standard\_DS2_v2 \


### PR DESCRIPTION
The CLI argument is meant for `az vm create` so it knows how big to make the disk size for the VM it is creating.