### PR TITLE
Update EBS Encryption property for Windows

### DIFF
--- a/cloudform-om-ebs-config.html.md.erb
+++ b/cloudform-om-ebs-config.html.md.erb
@@ -12,7 +12,7 @@ owner: Ops Manager
 
 Pivotal Cloud Foundry (PCF) supports Amazon Elastic Block Store (EBS) encryption for PCF deployments on AWS. You can use this feature to meet data-at-rest encryption requirements or as a security best practice. This feature uses AWS Key Management Service (KMS).
 
-<p class="note warning"><strong>Warning</strong>: Do not enable EBS encryption if you are running <strong>PAS for Windows</strong>. EBS encryption is currently incompatible with Windows VMs and it prevents Windows runtimes from installing.</p>
+<p class="note"><strong>Note:</strong>: EBS Encryption is for Linux VMs only. If you are running <strong>PAS for Windows</strong>, this configuration will not encrypt EBS volumes associated with Windows VMs.</p>
 
 By following the procedures in this topic, you can use full disk encryption for all persistent disks on the following VMs:
 


### PR DESCRIPTION
This PR is to update the docs that Enabling EBS Encryption setting doesn't break Windows deployments, but doesn't encrypt Windows VMs either. 