### PR TITLE
Correct supported components to document all supported external blobstores

### DIFF
--- a/backup-restore/backup-pcf-bbr.html.md.erb
+++ b/backup-restore/backup-pcf-bbr.html.md.erb
@@ -40,14 +40,19 @@ When using a backup to restore, you must ensure that the restore environment is 
 
 ## <a id='supported'></a> Supported Components
 
-BBR is a binary that can back up and restore BOSH deployments and BOSH Directors. BBR requires that the backup targets supply scripts that implement the backup and restore functions. BBR can communicate securely with external blobstores and databases, using TLS, if these are configured accordingly.
+BBR is a binary that can back up and restore BOSH deployments and BOSH Directors. BBR requires that the backup targets supply scripts that implement the backup and restore functions. BBR can communicate securely with external blobstores and databases, using TLS, if these are configured accordingly. BBR can backup PAS and the BOSH Director.
 
-BBR backs up the following PCF components:
+### PAS
+You can configure PAS with either an internal MySQL database or a supported external database. You can configure PAS with either WebDAV/NFS blobstore or a versioned S3-compatible external blobstore.
 
-* **PAS**: You can configure PAS with either an internal MySQL database or a supported external database. You can configure PAS with either WebDAV/NFS blobstore or a versioned S3-compatible external blobstore.
-    * **External databases:** For a list of supported external databases, see [Supported External Databases](https://docs.cloudfoundry.org/bbr/cf-backup.html#supported-external-databases) in the _Configuring Cloud Foundry for BOSH Backup and Restore_ in the Cloud Foundry documentation.
-    * **External blobstores:** BBR only supports PAS with versioned S3-compatible external blobstores. For more information, see [Backup and Restore with External Blobstores](https://docs.cloudfoundry.org/bbr/external-blobstores.html) in the Cloud Foundry documentation. To configure your PCF installation to use an external blobstore, see [External S3 or Ceph Filestore](../pcf-aws-manual-er-config.html#external_s3) in _Backing Up Pivotal Cloud Foundry with BBR_.
-* **BOSH Director**: The BOSH Director must have an internal Postgres database and an internal blobstore to be backed up and restored with BBR. As part of backing up the BOSH Director, BBR backs up the BOSH UAA database and the CredHub database.
+  * **External databases**&mdash;For a list of supported external databases, see [Supported External Databases](https://docs.cloudfoundry.org/bbr/cf-backup.html#supported-external-databases) in the _Configuring Cloud Foundry for BOSH Backup and Restore_ in the Cloud Foundry documentation.
+
+  * **External blobstores**&mdash;BBR supports PAS with configured with versioned or unversioned S3-compatible blobstores. To configure your PCF installation to use an external S3-compatible blobstore, see [External S3 or Ceph Filestore](../pcf-aws-manual-er-config.html#external_s3).
+
+  For more information, see [Backup and Restore with External Blobstores](https://docs.cloudfoundry.org/bbr/external-blobstores.html) in the Cloud Foundry documentation.
+
+### BOSH Director
+The BOSH Director must have an internal Postgres database and an internal blobstore to be backed up and restored with BBR. As part of backing up the BOSH Director, BBR backs up the BOSH UAA database and the CredHub database.
 
 <div class="note">
   <strong>Note:</strong>


### PR DESCRIPTION
Hi docs team, 

This is an update to document that in 2.2, BBR supports both versioned and unversioned external blobstores. This commit is for 2.2 only. 

Mirah & @snneji 
[#159659655]