### PR TITLE
Update AWS Permissions Required by Terraform

### DIFF
--- a/aws-prepare-env-terraform.html.md.erb
+++ b/aws-prepare-env-terraform.html.md.erb
@@ -26,8 +26,8 @@ In addition to fulfilling the prerequisites listed in the [Installing Pivotal Cl
   * AmazonRoute53FullAccess
   * AmazonS3FullAccess
   * AmazonVPCFullAccess
-  * AmazonIAMFullAccess
-  * AmazonKMSFullAccess
+  * IAMFullAccess
+  * AWSKeyManagementServicePowerUser
 
 ## <a id="download"></a>Step 1: Download and Edit the Terraform Variables File ##
 


### PR DESCRIPTION
This commit amends the permissions that are required for Terraform to run the tasks that are defined in the officially supported Terraform scripts. 

The required permissions have already been updated for other projects, such as [pcf-pipelines](https://github.com/pivotal-cf/terraforming-aws#aws-permissions), but the official documentation is still using old naming conventions for two permissions (permissions required for IAM and KMS operations).