### PR TITLE
Update BOSH UAA client authentication

### DIFF
--- a/opsmanager-create-bosh-client.html.md.erb
+++ b/opsmanager-create-bosh-client.html.md.erb
@@ -7,7 +7,14 @@ owners: Ops Manager
 
 _This topic assumes you are using [BOSH CLI v2+](https://bosh.io/docs/cli-v2.html)_.
 
-This topic describes the process of creating a UAA client for the BOSH Director. You must create an automation client to run BOSH from a script or set up a continuous integration pipeline.
+This topic describes the process of creating a UAA client for the BOSH Director.
+You must create an automation client to run BOSH from a script or set up a continuous integration pipeline.
+
+To create an automation client, do one of the following:
+
+- [Local Authentication](#local_auth): When using Internal Authentication, use the existing admin client to manually create an automation client with the correct privileges.
+
+- [Provision Admin Client](#saml): When setting up SAML authentication, ensure Ops Manager provisions an admin client.
 
 ##<a id="local_auth"></a> Local Authentication
 
@@ -15,23 +22,25 @@ To perform this procedure, the UAAC client must be installed on the Ops Manager 
 
 1. Open a terminal and SSH into the Ops Manager VM by following the instructions for your IaaS in the [SSH into Ops Manager](./trouble-advanced.html#ssh) topic. 
 
-1. Navigate to the Ops Manager **Installation Dashboard** and select the **BOSH Director** tile. In BOSH Director, click the **Status** tab, and copy the **BOSH Director** IP address. 
+1. Navigate to the Ops Manager **Installation Dashboard** and select the **BOSH Director** tile. In BOSH Director, click the **Status** tab, and record the IP address. 
 
 1. Using the `uaac target` command, target BOSH Director UAA on port `8443` using the IP address you copied, and specify the location of the root certificate. The default location is `/var/tempest/workspaces/default/root_ca_certificate`.
 
     <pre class='terminal'>
-    $ uaac target https://OPS-DIRECTOR-IP:8443 --ca-cert \
+    $ uaac target https://BOSH-DIRECTOR-IP:8443 --ca-cert \
     /var/tempest/workspaces/default/root_ca_certificate
 
     Target: http<span>s</span>://10.85.16.4:8443
     </pre>
+    Where:
+    - `BOSH-DIRECTOR-IP` is the IP you recorded in the **Status** tab of the BOSH Director.
 
     <p class="note"><strong>Note</strong>: You can also curl or point your browser to the following endpoint to obtain the root certificate: <code>https://OPS-MANAGER-FQDN/api/v0/security/root_ca_certificate</code></p>
 
 1. Log in to the BOSH Director UAA and retrieve the owner token. Perform the following step to obtain the values for `UAA-LOGIN-CLIENT-PASSWORD` and `UAA-ADMIN-CLIENT-PASSWORD`:
-       * Select the **BOSH Director** tile from the Ops Manager **Installation Dashboard**. 
-       * Click the **Credentials** tab, and locate the entries for **Uaa Login Client Credentials** and **Uaa Admin User Credentials**. 
-       * For each entry, click **Link to Credential** to obtain the password. 
+       1. Select the **BOSH Director** tile from the Ops Manager **Installation Dashboard**. 
+       1. Click the **Credentials** tab, and record the entries for **Uaa Login Client Credentials** and **Uaa Admin User Credentials**. 
+       1. For each entry, click **Link to Credential** to obtain the password. 
        <pre class='terminal'>
        $ uaac token owner get login -s UAA-LOGIN-CLIENT-PASSWORD
        User name:  admin
@@ -69,36 +78,48 @@ To perform this procedure, the UAAC client must be installed on the Ops Manager 
   	$ ubuntu@ip-10-0-0-12:~$ export BOSH_CLIENT_SECRET=CI-SECRET
 	</pre>
 
-1. Set an alias for the BOSH Director environment. Replace `DIRECTOR-IP` with the IP address of your BOSH Director VM.
-
+1. Set an alias for the BOSH Director environment. 
     <pre class='terminal'>
-    $ bosh alias-env MY-ENVIRONMENT-NAME -e DIRECTOR-IP \
+    $ bosh alias-env MY-ENVIRONMENT-NAME -e BOSH-DIRECTOR-IP \
     --ca-cert /var/tempest/workspaces/default/root_ca_certificate
     </pre>
+
     You can now use the UAA client you created to run BOSH in automated or scripted environments, such as continuous integration pipelines.
 
-## <a id="saml"></a> SAML Authentication to the BOSH Director
+## <a id="saml"></a> Provision Admin Client
 
-Typically, there is no browser access to a BOSH Director in order to authenticate using SAML. 
-Ops Manager provides an option to create UAA clients during SAML configuration so that BOSH can be automated via scripts and tooling. 
+Pivotal does not support SAML authentication to the BOSH Director.
+Ops Manager provides an option to create UAA clients during SAML configuration so that BOSH can be automated using scripts and tooling.
 
 1. Select **Provision an admin client in the Bosh UAA** when configuring Ops Manager for SAML.
 
-2. After deploying BOSH Director (BOSH), click the Credentials tab in the BOSH Director tile.
+2. After deploying BOSH Director (BOSH), click the **Status** tab, and record the IP address. 
 
-3. Click the link for the **Uaa Bosh Client Credentials** to get the client name and secret.
+3. Click the **Credentials** tab in the BOSH Director tile.
 
-4. Open a terminal and SSH into the Ops Manager VM. Follow the instructions for your SSH in the [SSH into Ops Manager](trouble-advanced.html#ssh) topic.
+4. Click the link for the **Uaa Bosh Client Credentials** to record the client name and secret.
+
+5. Open a terminal and SSH into the Ops Manager VM. Follow the instructions for your SSH in the [SSH into Ops Manager](trouble-advanced.html#ssh) topic.
   
-5. Set the client and secret as environment variables on the Ops Manager VM.
+6. Set the client and secret as environment variables on the Ops Manager VM.
+   ```
+     export BOSH_CLIENT=bosh_admin_client
+     export BOSH_CLIENT_SECRET=UAA-BOSH-CLIENT-SECRET
+   ```
+   Where:
+   - `UAA-BOSH-CLIENT-SECRET` is the client secret you recorded in Step 4.
+   For example:
    <pre class='terminal'>
     $ ubuntu@ip-10-0-0-12:~$ export BOSH_CLIENT=bosh_admin_client
-    $ ubuntu@ip-10-0-0-12:~$ export BOSH_CLIENT_SECRET=CLIENT_SECRET
+    $ ubuntu@ip-10-0-0-12:~$ export BOSH_CLIENT_SECRET=aBcDeFGhijKabdsadfdfdf
    </pre>
 
-6. Set an alias for the BOSH Director environment. Replace `DIRECTOR-IP` with the IP address of your BOSH Director VM.
+
+7. Set an alias for the BOSH Director environment.
 
     <pre class='terminal'>
-    $ bosh alias-env MY-ENVIRONMENT-NAME -e DIRECTOR-IP \
+    $ bosh alias-env MY-ENVIRONMENT-NAME -e BOSH-DIRECTOR-IP \
     --ca-cert /var/tempest/workspaces/default/root_ca_certificate
     </pre>
+    Where:
+    - `BOSH-DIRECTOR-IP` is the IP you recorded in the **Status** tab of the BOSH Director.


### PR DESCRIPTION
The 2.2 version of https://github.com/pivotal-cf/docs-pcf-install/pull/494

This PR
- clarifies the language around setting up an automation client to access the BOSH director 
