### PR TITLE
Update gcp-prepare-env-terraform.html.md.erb

### DIFF
--- a/gcp-prepare-env-terraform.html.md.erb
+++ b/gcp-prepare-env-terraform.html.md.erb
@@ -57,7 +57,7 @@ Before you can run Terraform commands to create infrastructure resources, you mu
 1. Create a new file named `terraform.tfvars`. 
   <pre class="terminal">$ touch terraform.tfvars</pre>
 
-1. Open the `terraform.tfvars` file and paste in the following contents:
+1. Open the `terraform.tfvars` file and paste in the following contents [Ensure that you insert a newline at the end of the file]:
 
     ```
     env_name         = "YOUR-ENVIRONMENT-NAME"
@@ -82,6 +82,7 @@ Before you can run Terraform commands to create infrastructure resources, you mu
     service_account_key = <<SERVICE_ACCOUNT_KEY
     YOUR-KEY-JSON
     SERVICE_ACCOUNT_KEY
+
     ```
 
 1. Edit the values in the file according to the table below:
@@ -166,7 +167,8 @@ iso_seg_ssl_cert = <<ISO_SEG_SSL_CERT
 YOUR-CERTIFICATE
 -----END CERTIFICATE-----
 ISO_SEG_SSL_CERT
-iso_seg_ssl_cert_private_key = <<ISO_SEG_SSL_KEY
+
+iso_seg_ssl_private_key = <<ISO_SEG_SSL_KEY
 -----BEGIN EXAMPLE RSA PRIVATE KEY-----
 YOUR-PRIVATE-KEY
 -----END EXAMPLE RSA PRIVATE KEY-----


### PR DESCRIPTION
Fixed the variable for the iso seg private key, which is referenced incorrectly in the variables file
Added note to include a newline at the end of the terraform.tfvars file.  terraform plan -out=plan will fail if this is not included.