### PR TITLE
Fixed typo at Step 23 at "Deploying PAS on AWS"

### DIFF
--- a/pcf-aws-manual-er-config.html.md.erb
+++ b/pcf-aws-manual-er-config.html.md.erb
@@ -185,7 +185,7 @@ PAS uses SMTP to send invitations and confirmations to Apps Manager users. You m
 1. In the PAS tile, click **Resource Config**.
   <%= image_tag("images/resource_config.png") %>
 
-1. Enter the name of you SSH load balancer depending on which release you are using. You can specify multiple load balancers by entering the names separated by commas.
+1. Enter the name of your SSH load balancer depending on which release you are using. You can specify multiple load balancers by entering the names separated by commas.
   * **PAS**: In the **ELB Name** field of the **Diego Brain** row, enter the name of your SSH load balancer: `pcf-ssh-elb`.
   * **Small Footprint Runtime**: In the **ELB Name** field of the **Control** row, enter the name of your SSH load balancer: `pcf-ssh-elb`.
 


### PR DESCRIPTION
Please fix the typo as below.

"3. Enter the name of you SSH load ..." -> "3. Enter the name of your SSH load ..."