### PR TITLE
Missing link for Azure Storage

### DIFF
--- a/aws-er-config-terraform.html.md.erb
+++ b/aws-er-config-terraform.html.md.erb
@@ -203,7 +203,7 @@ For additional factors to consider when selecting file storage, see the [Conside
 
 ### <a id='other'></a> Other IaaS Storage Options
 
-[Google Cloud Storage](./gcp-er-config.html#external_gcp) and [Azure Storage](./gcp-er-config.html#external_azure) are also available as file storage options, but are not recommended for typical PCF on AWS installations. 
+[Google Cloud Storage](./gcp-er-config.html#external_gcp) and [Azure Storage](./azure-er-config.html#external_azure) are also available as file storage options, but are not recommended for typical PCF on AWS installations. 
 
 
 ## <a id='sys-logging'></a> Step 15: (Optional) Configure System Logging


### PR DESCRIPTION
As an other IaaS storage option, the link for Azure Storage is wrong.