### PR TITLE
Missing the link for Azure Storage

### DIFF
--- a/pcf-aws-manual-er-config.html.md.erb
+++ b/pcf-aws-manual-er-config.html.md.erb
@@ -126,7 +126,7 @@ For more factors to consider when selecting file storage, see the [Consideration
 
 ### <a id='other'></a> Other IaaS Storage Options
 
-[Google Cloud Storage](./gcp-er-config.html#external_gcp) and [Azure Storage](./gcp-er-config.html#external_azure) are also available as file storage options, but are not recommended for typical PCF on AWS installations. 
+[Google Cloud Storage](./gcp-er-config.html#external_gcp) and [Azure Storage](./azure-er-config.html#external_azure) are also available as file storage options, but are not recommended for typical PCF on AWS installations. 
 
 ## <a id='sys-logging'></a> Step 14: (Optional) Configure System Logging
 


### PR DESCRIPTION
As an other IaaS storage option in docs for installing PCF on AWS manually, the link fo Azure store is wrong.