### PR TITLE
Correct steps for NAT setup on GCP

### DIFF
--- a/gcp-prepare-env.html.md.erb
+++ b/gcp-prepare-env.html.md.erb
@@ -211,7 +211,8 @@ For more information, see [Reference Architecture for Pivotal Cloud Foundry on G
   ![Management dropdown](gcp/gcp-nat-dropdown.png)
   1. In the **Startup script** field under **Automation**, enter the following text: 
       <code>#! /bin/bash<br>
-      sudo sh -c 'echo 1 > /proc/sys/net/ipv4/ip_forward'<br>
+      sudo sysctl -w net.ipv4.ip_forward=1<br>
+      sudo sh -c 'echo net.ipv4.ip_forward=1 | sudo tee -a /etc/sysctl.conf > /dev/null'<br>
       sudo iptables -t nat -A POSTROUTING -o eth0 -j MASQUERADE</code>
       ![Startup Script](gcp/gcp-nat-startup.png)
 


### PR DESCRIPTION
Update the directions for setting up the NAT instances on GCP to conform
with the knowledge base article from June.  In June an issue was
discovered with the GCP NAT setup where in some cases (package updates),
the settings per directions will not persist. These directions will
ensure that settings persist and will be more resilient.

https://community.pivotal.io/s/article/Loss-of-network-connectivity-on-Google-Cloud-Platform-after-applying-security-patch-DSA-4208