### PR TITLE
Wrong link for Configure a Security Group

### DIFF
--- a/aws-om-upgrade.html.md.erb
+++ b/aws-om-upgrade.html.md.erb
@@ -57,7 +57,7 @@ The default persistent disk value is 50 GB. Pivotal recommends increasing this v
 1. Click **Next: Tag Instance** 
 1. On the **Add Tags** page, add a tag with the key `Name` and value `pcf-ops-manager`. 
 1. Click **Next: Configure Security Group**.
-1. Select the `pcf-ops-manager-security-group` that you created in [Step 5: Configure a Security Group for Ops Manager](#pcfaws-om-secgrp).
+1. Select the `pcf-ops-manager-security-group` that you created in [Step 5: Configure a Security Group for Ops Manager](./pcf-aws-manual-config.html#pcfaws-om-secgrp).
 1. Click **Review and Launch** and confirm the instance launch details.
 1. Click **Launch**.
 1. Select the `pcf-ops-manager-key` key pair, confirm that you have access to the private key file, and click **Launch Instances**. You use this key pair to access the Ops Manager VM.


### PR DESCRIPTION
Fixed the wrong link for "Step 5: Configure a Security Group for Ops Manager"