### PR TITLE
Missing link to migrate Percona MySQL

### DIFF
--- a/_ert_database_internal.html.md.erb
+++ b/_ert_database_internal.html.md.erb
@@ -5,7 +5,7 @@ If you want to use internal databases for your deployment, perform the following
 1. Select one of the **Internal Databases** options:
   - **Internal Databases - MySQL - Percona XtraDB Cluster** uses [Percona Server](https://www.percona.com/software/mysql-database/percona-server) with TLS encryption between server cluster nodes.
   - **Internal Databases - MySQL - MariaDB Galera Cluster** uses [MariaDB](http://www.mariadb.org) with cluster nodes communicating over plaintext.
-  <p class="note warning"><strong>WARNING</strong>: Changing existing internal databases from <strong>MySQL - MariaDB Galera Cluster</strong> to <strong>MySQL - Percona XtraDB Cluster</strong> migrates the databases after you click <strong>Apply Changes</strong>, causing temporary system downtime. See <a href="../opsguide/internal-databases.html#migrate">Migrate to Internal Percona MySQL</a> for details.</p>
+  <p class="note warning"><strong>WARNING</strong>: Changing existing internal databases from <strong>MySQL - MariaDB Galera Cluster</strong> to <strong>MySQL - Percona XtraDB Cluster</strong> migrates the databases after you click <strong>Apply Changes</strong>, causing temporary system downtime. See <a href="../opsguide/internal-databases.html#migrate-percona-mysql">Migrate to Internal Percona MySQL</a> for details.</p>
    <%= image_tag("system-db-tls.png") %>
 
 1. Click **Save**.


### PR DESCRIPTION
The link to migrate internal Percona MySQL is wrong.