### PR TITLE
Modify link for How to set up a load balancer

### DIFF
--- a/azure-om-config-terraform.html.md.erb
+++ b/azure-om-config-terraform.html.md.erb
@@ -136,7 +136,7 @@ To complete the procedures in this topic, you must have access to the output fro
 
 1. (Optional) **Max Threads** sets the maximum number of threads that the BOSH Director can run simultaneously. Pivotal recommends that you leave the field blank to use the default value, unless doing so results in rate limiting or errors on your IaaS.
 
-1. (Optional) To add a custom URL for your BOSH Director, enter a valid hostname in **Director Hostname**. You can also use this field to configure a load balancer in front of your BOSH Director. For more information, see [How to set up a load balancer in front of BOSH Director](https://discuss.pivotal.io/hc/en-us/articles/225420588) in the Pivotal Knowledge Base.
+1. (Optional) To add a custom URL for your BOSH Director, enter a valid hostname in **Director Hostname**. You can also use this field to configure a load balancer in front of your BOSH Director. For more information, see [How to set up a load balancer in front of BOSH Director](https://community.pivotal.io/s/article/How-to-Set-Up-a-Load-Balancer-in-Front-of-Ops-Manager-Director) in the Pivotal Knowledge Base.
 
 1. <%= partial "exclude-recursors" %>
 


### PR DESCRIPTION
Modified link for "How to set up a load balancer in front of BOSH Director."

So far the URL link works but it's obsolete and it's redirected to the current one.