### PR TITLE
Specify NSX-T tile version 2.3 or later

### DIFF
--- a/vsphere-nsx-t.html.md.erb
+++ b/vsphere-nsx-t.html.md.erb
@@ -10,7 +10,7 @@ This topic describes how to install Pivotal Application Service (PAS) on vSphere
 
 ## <a id='introduction'></a> Introduction
 
-PAS v2.0 uses a Container Network Interface (CNI) plugin to support secure and direct internal communication between containers. This plugin can be:
+PAS v2.3 uses a Container Network Interface (CNI) plugin to support secure and direct internal communication between containers. This plugin can be:
 
 * The internal Silk plugin that comes packaged with PAS, or
 * On vSphere, [VMware NSX-T Container Plug-in for PCF](https://network.pivotal.io/products/vmware-nsx-t), which installs as an Ops Manager tile.
@@ -18,8 +18,8 @@ PAS v2.0 uses a Container Network Interface (CNI) plugin to support secure and d
 
 ## <a id='requirements'></a> Requirements
 
-* An NSX-T 2.1 environment with NSX-T components installed and configured. See the [NSX-T Cookbook](https://docs.google.com/document/d/1hw7USpyMZpKoT5MvSaP9NcnTHsdvMd_w0EGZ19cL8nQ) for directions.
-* BOSH and Ops Manager v2.0 or later installed and configured on vSphere. See [Deploying BOSH and Ops Manager to vSphere](./deploying-vm.html) for directions.
+* An NSX-T 2.2 or later environment with NSX-T components installed and configured. See the [NSX-T Cookbook](https://docs.google.com/document/d/1hw7USpyMZpKoT5MvSaP9NcnTHsdvMd_w0EGZ19cL8nQ) for directions.
+* BOSH and Ops Manager v2.3 or later installed and configured on vSphere. See [Deploying BOSH and Ops Manager to vSphere](./deploying-vm.html) for directions.
 * The [VMWare NSX-T Container Plug-in for PCF tile](https://network.pivotal.io/products/vmware-nsx-t) downloaded from Pivotal Network and imported to the Ops Manager **Installation Dashboard**. See [Adding and Importing Products](./add-delete.html#add-import) for how to download and import Pivotal products to the **Installation Dashboard**.
 * The [PAS tile](https://network.pivotal.io/products/elastic-runtime) downloaded from Pivotal Network and imported to the Ops Manager **Installation Dashboard**. The PAS tile must be in one of the following two states:
   * Not deployed yet; you have not yet clicked **Review Pending Changes**, then **Apply Changes** on this version of PAS.
@@ -147,7 +147,7 @@ Installing NSX-T to run with PAS requires the following actions, which are descr
 
 ### <a id='nsx-t-tile'></a> Install and Configure the NSX-T tile
 
-1. If you have not already done so, download the VMware NSX-T tile from [Pivotal Network](https://network.pivotal.io/products/vmware-nsx-t) and import it to the **Installation Dashboard**. See [Adding and Importing Products](./add-delete.html#add-import) for directions.
+1. If you have not already done so, download the VMware NSX-T tile version 2.3 or later from [Pivotal Network](https://network.pivotal.io/products/vmware-nsx-t) and import it to the **Installation Dashboard**. See [Adding and Importing Products](./add-delete.html#add-import) for directions.
 ![Ops Manager Installation Dashboard with NSX-T tile](nsx-t/nsx-t-install-dash.png)
 
 1. Click the **VMware NSX-T** tile to open its **Settings** tab, and configure the **NSX Manager** pane as follows:


### PR DESCRIPTION
PAS 2.3 is known *not* to work with versions 2.2 and earlier of the NSX-T tile (due to stemcell incompatibilities).

Version 2.3 of the NSX-T tile will not work with versions 2.1 or earlier of NSX-T infrastructure (generally, VMware supports versions N and N-1 of the NSX-T infrastructure for each NSX-T tile), so we should also specify that NSX-T infrastructure version must be at least 2.2.