### PR TITLE
Update OpsMgr for vSphere install on ssh key setup

### DIFF
--- a/deploying-vm.html.md.erb
+++ b/deploying-vm.html.md.erb
@@ -47,7 +47,7 @@ This topic provides instructions for deploying Ops Manager to VMware vSphere.
         1. Select a network from the drop down list and click **Next**.
     1. **Customize template**
         1. In the **Admin Password** field, enter a default password for the account with the username `ubuntu`. Alternatively, you can enter a pre-existing SSH key value in the **Public SSH Key** field. 
-            <p class="note"><strong>Note</strong>: You must specify either a default password or an SSH key (or specify both). If you do not have either of these fields configured, Ops Manager will not boot up.</p>
+            <p class="note"><strong>Note</strong>: You must specify a default password, an SSH key, or both. If you do not have either of these fields configured, Ops Manager will not boot up.</p>
         1. Complete the remaining network information and passwords for the Ops Manager VM admin user.
             <p class="note"><strong>Note</strong>: Record this network information. The IP Address will be the location of the Ops Manager interface.</p>
         1. Click **Next**.

--- a/deploying-vm.html.md.erb
+++ b/deploying-vm.html.md.erb
@@ -47,7 +47,7 @@ This topic provides instructions for deploying Ops Manager to VMware vSphere.
         1. Select a network from the drop down list and click **Next**.
     1. **Customize template**
         1. In the **Admin Password** field, enter a default password for the account with the username `ubuntu`. Alternatively, you can enter a pre-existing SSH key value in the **Public SSH Key** field. 
-            <p class="note"><strong>Note</strong>: You must specify either a default password or an SSH key. If you do not have either of these fields configured, Ops Manager will not boot up.</p>
+            <p class="note"><strong>Note</strong>: You must specify either a default password or an SSH key (or specify both). If you do not have either of these fields configured, Ops Manager will not boot up.</p>
         1. Complete the remaining network information and passwords for the Ops Manager VM admin user.
             <p class="note"><strong>Note</strong>: Record this network information. The IP Address will be the location of the Ops Manager interface.</p>
         1. Click **Next**.


### PR DESCRIPTION
The documentation does not match the OpsMgr installation user interface with regards to the support for the setup of both  default password and an SSH key.