### PR TITLE
Update docs on topic backing up services

### DIFF
--- a/backup-restore/backup-pcf-bbr.html.md.erb
+++ b/backup-restore/backup-pcf-bbr.html.md.erb
@@ -106,10 +106,10 @@ If you configured an unsupported external blobstore or an unsupported external d
 
 Keep in mind the following when backing up services:
 
-* You can back up and restore brokered services with the procedures documented in this topic and in the [Restoring Pivotal Cloud Foundry from Backup with BBR](restore-pcf-bbr.html) topic. BBR backs up and restores the VMs and the service instances, but not the service data.
+* BBR backs up and restores the service bindings, but not the service data.
 * You can redeploy on-demand service instances manually during restore, but the data in the instance is not backed up.
 * BBR does not back up managed services or their data.
-
+* You can back up and restore brokered services with the procedures documented in this topic and in the [Restoring Pivotal Cloud Foundry from Backup with BBR](restore-pcf-bbr.html) topic. 
 
 ## <a id='workflow'></a> Workflow
 


### PR DESCRIPTION
Hi!

The Platform Recovery(bbr) team here. We recently received feedback that our docs on backing services were a bit misleading. This PR updates the section and make it clear that we do not back up any services data.

Please back port the same changes to PCF 1.11, 1.12, 2.0, 2.1, and 2.2.

Cheers!

[#160019107]