### PR TITLE
Wrong topic name

### DIFF
--- a/gcp-om-deploy.html.md.erb
+++ b/gcp-om-deploy.html.md.erb
@@ -9,7 +9,7 @@ owner: Ops Manager
 This topic describes how to deploy BOSH Director for Pivotal Cloud Foundry (PCF) on Google Cloud Platform (GCP).
 
 After you complete this procedure, follow the instructions in the [Configuring BOSH Director on GCP](./gcp-om-config.html) and
-[Configuring PAS on GCP](./gcp-er-config.html) topics.
+[Deploying PAS on GCP](./gcp-er-config.html) topics.
 
 ## <a id='select-tgz'></a>Step 1: Locate the Pivotal Ops Manager Installation File ##
 


### PR DESCRIPTION
The topic name for gcp-er-config.html is "Deploying PAS on GCP" rather than "Configuring PAS on GCP."