### PR TITLE
URL link for a KB article is obsolted

### DIFF
--- a/_using_ldap_server_ops_manager.html.md.erb
+++ b/_using_ldap_server_ops_manager.html.md.erb
@@ -32,7 +32,7 @@ all LDAP objects with the same common name as the username.
 <br><br>
 In addition to `cn`, other attributes commonly searched for and returned are
 `mail`, `uid` and, in the case of Active Directory, `sAMAccountName`.
-    <p class="note"><strong>Note</strong>: For instructions for testing and troubleshooting your LDAP search filters, see the [Configuring LDAP Integration with Pivotal Cloud Foundry](https://discuss.zendesk.com/hc/en-us/articles/204140418-Configuring-LDAP-Integration-with-Pivotal-Cloud-Foundry-) Knowledge Base article.</p>
+    <p class="note"><strong>Note</strong>: For instructions for testing and troubleshooting your LDAP search filters, see the [Configuring LDAP Integration with Pivotal Cloud Foundry](https://community.pivotal.io/s/article/Configuring-LDAP-Integration-with-Pivotal-Cloud-Foundry) Knowledge Base article.</p>
 
 * For **Group Search Base**, enter the location in the LDAP directory tree
 from which the LDAP Group search begins.


### PR DESCRIPTION
The URL link for the KB "Configuring LDAP Integration with Pivotal Cloud Foundry®" has been obsoleted based on the older Pivotal support system as below.
https://discuss.zendesk.com/hc/en-us/articles/204140418-Configuring-LDAP-Integration-with-Pivotal-Cloud-Foundry-

This should be as below based on the new Pivotal support system.
https://community.pivotal.io/s/article/Configuring-LDAP-Integration-with-Pivotal-Cloud-Foundry