### PR TITLE
Remove AzureStack VM Size adjustment

### DIFF
--- a/azure-om-config.html.md.erb
+++ b/azure-om-config.html.md.erb
@@ -24,11 +24,9 @@ Before you perform the procedures in this topic, you must have completed the pro
 
 ### <a id="stack-gov-prereqs"></a> Prerequisites for Azure Stack or Azure Government Cloud
 
-If you are using Azure Stack or Azure Government Cloud, you must set custom VM types for a successful deployment. You can set custom VM types with the Ops Manager API. For more information, see [Using the Ops Manager API](ops-man-api.html).
+If you are using Azure Government Cloud, you must set custom VM types for a successful deployment. You can set custom VM types with the Ops Manager API. For more information, see [Using the Ops Manager API](ops-man-api.html).
 
 To set custom VM types, see the following information.
-
-* **For Azure Stack:** The example below may not have up-to-date VM types. For a current list of supported Azure Stack VM types that you can include in your API call, see [Virtual Machine Sizes](https://docs.microsoft.com/en-us/azure/azure-stack/user/azure-stack-vm-considerations#virtual-machine-sizes) from the Azure Stack documentation. Include at least one `Standard` VM type.
 
 * **For Azure Government:** See the example `curl` command below for your list of VM types.
 
@@ -37,26 +35,9 @@ To set custom VM types, see the following information.
     <th colspan="2">Example Command to Set VM Types</th>
   </tr>
   <tr>
-    <th>Azure Stack</th>
     <th>Azure Government</th>
   </tr>
   <tr>
-    <td>
-<pre class="terminal" style="max-width: 300px; height: 300px; overflow: auto;">
-$ curl -k https://YOUR-OPS-MAN-FQDN/api/v0/vm_types -X
-PUT -H "Authorization: bearer UAA-ACCESS-TOKEN"
-"Content-Type: application/json" -d '{"vm_types":[
-{"name":"Standard_DS1_v2","ram":3584,"cpu":1,"ephemeral_disk":51200},
-{"name":"Standard_DS2_v2","ram":7168,"cpu":2,"ephemeral_disk":102400},
-{"name":"Standard_DS3_v2","ram":14336,"cpu":4,"ephemeral_disk":204800},
-{"name":"Standard_DS4_v2","ram":28672,"cpu":8,"ephemeral_disk":409600},
-{"name":"Standard_DS5_v2","ram":57344,"cpu":8,"ephemeral_disk":819200},
-{"name":"Standard_DS11_v2","ram":14336,"cpu":2,"ephemeral_disk":102400},
-{"name":"Standard_DS12_v2","ram":28672,"cpu":4,"ephemeral_disk":204800},
-{"name":"Standard_DS13_v2","ram":57344,"cpu":8,"ephemeral_disk":409600},
-{"name":"Standard_DS14_v2","ram":114688,"cpu":16,"ephemeral_disk":819200}]}''
-</pre>
-    </td>
     <td>
 <pre class="terminal" style="max-width: 300px;; height: 300px; overflow: auto;">
 $ curl -k https://YOUR-OPS-MAN-FQDN/api/v0/vm_types -X


### PR DESCRIPTION
AzureStack as all CPI required/supported VM Types since 1804 Release. Latest Supported N-2 is 185, so there is no need to adjust VM types right now for Azure Stack.

see https://docs.microsoft.com/en-us/azure/azure-stack/user/azure-stack-vm-sizes