### PR TITLE
network interface private-ip-address not in range

### DIFF
--- a/azure-om-deploy.html.md.erb
+++ b/azure-om-deploy.html.md.erb
@@ -369,7 +369,7 @@ Azure for PCF uses multiple general-purpose Azure storage accounts. The BOSH and
     <pre class="terminal">
     $ az network nic create --vnet-name PCF \
     --subnet Management --network-security-group opsmgr-nsg \
-    --private-ip-address 10.0.0.5 \
+    --private-ip-address 10.0.4.4 \
     --public-ip-address ops-manager-ip \
     --resource-group $RESOURCE_GROUP \
     --name opsman-nic --location $LOCATION


### PR DESCRIPTION
Based on the subnet, the private ip needs to be in range. Two suggestions, use 10.0.4.4 or omit and let Azure fill it in. Update with IP to retain structure.