### PR TITLE
Update Security Groups for OpenStack

### DIFF
--- a/openstack-setup.html.md.erb
+++ b/openstack-setup.html.md.erb
@@ -90,22 +90,57 @@ After completing this procedure, complete all of the steps in the [Configuring B
         <td>Ingress</td>
         <td>IPv4</td>
         <td>TCP</td>
-        <td>25555</td>
-        <td>0.0.0.0/0 (CIDR)</td>
+        <td>4222 (NATS)</td>
+        <td>opsmanager</td>
       </tr>
       <tr>
         <td>Ingress</td>
         <td>IPv4</td>
         <td>TCP</td>
-        <td>1-65535</td>
+        <td>6868 (BOSH Agent)</td>
         <td>opsmanager</td>
       </tr>
       <tr>
         <td>Ingress</td>
         <td>IPv4</td>
-        <td>UDP</td>
-        <td>1-65535</td>
+        <td>TCP</td>
+        <td>8844 (CredHub)</td>
         <td>opsmanager</td>
+      </tr>
+      <tr>
+        <td>Ingress</td>
+        <td>IPv4</td>
+        <td>TCP</td>
+        <td>8853 (BOSH Health Monitor)</td>
+        <td>opsmanager</td>
+      </tr>
+      <tr>
+        <td>Ingress</td>
+        <td>IPv4</td>
+        <td>TCP</td>
+        <td>25250 (BOSH Blobstore)</td>
+        <td>opsmanager</td>
+      </tr>
+      <tr>
+        <td>Ingress</td>
+        <td>IPv4</td>
+        <td>TCP</td>
+        <td>25555 (BOSH Director)</td>
+        <td>opsmanager</td>
+      </tr>
+      <tr>
+        <td>Ingress</td>
+        <td>IPv4</td>
+        <td>TCP</td>
+        <td>25777 (BOSH Registry)</td>
+        <td>opsmanager</td>
+      </tr>
+      <tr>
+        <td>Egress</td>
+        <td>IPv4</td>
+        <td>TCP</td>
+        <td>1-65535</td>
+        <td>0.0.0.0/0 (CIDR)</td>
       </tr>
     </table>
 


### PR DESCRIPTION
Security Groups rules for OpenStack are more precise (key takeaways from a customer installation).