### PR TITLE
Update link to OpsManager API docs to 2.3

### DIFF
--- a/ops-man-api.html.md.erb
+++ b/ops-man-api.html.md.erb
@@ -11,7 +11,7 @@ Platform operators use the Ops Manager API to automate deployments, retrieve and
 
 For the complete Ops Manager API documentation, see either of the following:
 
-* https://docs.pivotal.io/pivotalcf/2-2/opsman-api
+* https://docs.pivotal.io/pivotalcf/2-3/opsman-api
 * `https://YOUR-OPS-MANAGER-FQDN/docs`, adding `/docs` to the URL of your Ops Manager
 
 
@@ -119,7 +119,7 @@ If you configured your Ops Manager for an external Identity Provider with SAML, 
 
 Ops Manager uses authorization tokens to allow access to the API. You must pass an access token to the API endpoint in a header that follows the format `Authorization: Bearer YOUR-ACCESS-TOKEN`.
 
-The following example procedure retrieves a list of deployed products. See the [Ops Manager API documentation](https://docs.pivotal.io/pivotalcf/2-2/opsman-api) for the full range of API endpoints.
+The following example procedure retrieves a list of deployed products. See the [Ops Manager API documentation](https://docs.pivotal.io/pivotalcf/2-3/opsman-api) for the full range of API endpoints.
 
 If you use Internal Authentication, you must perform the following procedures from the Ops Manager VM. If you use an External Identity Provider, you may perform the procedures from your local machine.
 


### PR DESCRIPTION
Currently the 2.3 docs link to the 2.2 OpsManager API documentation.  This patch updates those links