### PR TITLE
Remove "Ops manager is deployed by BOSH"

### DIFF
--- a/deploy-bosh-om.html.md.erb
+++ b/deploy-bosh-om.html.md.erb
@@ -15,7 +15,7 @@ This documentation explains how to deploy BOSH and Ops Manager, the foundation o
   - BOSH and its IaaS-specific Cloud Provider Interfaces (CPIs) are what enable PCF to run on multiple IaaSes.
   - See [Deploying Software with BOSH](#bosh) for a mini overview of how you use BOSH to run software in the cloud.
 
-* **Ops Manager** is a GUI application deployed by BOSH that streamlines deploying subsequent software to the cloud via BOSH.
+* **Ops Manager** is a GUI application that streamlines deploying subsequent software to the cloud via BOSH.
   - For routine tasks, operators can use the Ops Manager interface instead of the BOSH command-line interface (CLI) or BOSH API.
   - Ops Manager represents PCF products as _tiles_ with multiple configuration panes that let you input or select configuration values needed for the product.
   - Ops Manager generates BOSH manifests containing the user-supplied configuration values, and sends them to the Director.


### PR DESCRIPTION
Removed "deployed by BOSH" from "Ops Manager is a GUI application deployed by BOSH that..." as Ops manager is not deployed by bosh, its the other way around.