### PR TITLE
use deployment network for deploying

### DIFF
--- a/azure-er-config.html.md.erb
+++ b/azure-er-config.html.md.erb
@@ -39,7 +39,7 @@ Before you perform the procedures in this topic, you must have completed the pro
 
 1. Select **Assign Networks**.
 
-1. From the **Network** dropdown menu, select the network on which you want to run PAS.
+1. From the **Network** dropdown menu, select the network on which you want to run PAS, eg. Deployment.
 
 	<%= image_tag("azure/assign-networks.png") %>
 


### PR DESCRIPTION
the picture points to the management Network to be used. according to the Ref Arch, this should be deployment / PAS network ( created as Deployment Network from earlier step )

picture shall show Deployment and not management

![image](https://user-images.githubusercontent.com/8255007/48733288-80574600-ec42-11e8-8bf4-3cbe906ab05d.png)
