### PR TITLE
Removed incorrect information regarding backup-restore/prepare node

### DIFF
--- a/_disable_resources.html.md.erb
+++ b/_disable_resources.html.md.erb
@@ -22,7 +22,6 @@ enter `0` in **Instances** in the **File Storage** field.
     * **MySQL Proxy**: Enter `0` in **Instances**.
     * **MySQL Server**: Enter `0` in **Instances**.
     * **MySQL Monitor**: Enter `0` in **Instances**.
-    * **Backup Restore Node**: Enter `0` in **Instances**.
 
 1. If you disabled TCP routing, enter `0` **Instances** in the **TCP Router** field.
 

--- a/_disable_resources_azure.html.md.erb
+++ b/_disable_resources_azure.html.md.erb
@@ -22,7 +22,6 @@ enter `0` in **Instances** in the **File Storage** field.
     * **MySQL Proxy**: Enter `0` in **Instances**.
     * **MySQL Server**: Enter `0` in **Instances**.
     * **MySQL Monitor**: Enter `0` in **Instances**.
-    * **Backup Restore Node**: Enter `0` in **Instances**.
 
 1. If you disabled TCP routing, enter `0` **Instances** in the **TCP Router** field.
 


### PR DESCRIPTION
The Backup Restore node (Backup Prepare in <2.3) instance count should always be set to one in order for a backup to order with bbr.  Could you please add these changes to PAS 2.0, 2.1, 2.2, 2.3, 2.4 onwards

[#162553155]

Signed-off-by: Mehul Modha <mmodha@pivotal.io>