### PR TITLE
Clarify NSX-T procedure necessity

### DIFF
--- a/update-nsx-t.html.md.erb
+++ b/update-nsx-t.html.md.erb
@@ -6,13 +6,19 @@ owner: Ops Manager
 <strong><%= modified_date %></strong>
 
 This topic describes how to update load balancer server pool membership
-for Pivotal Cloud Foundry (PCF) deployments using NSX-T on vSphere. To update
-this information, you must use the Ops Manager API.
+for Pivotal Cloud Foundry (PCF) foundation using NSX-T on vSphere.
 
-See the [Ops Manager API documentation](https://docs.pivotal.io/pivotalcf/2-3/opsman-api) for more information about the API.
+This procedure applies to customers who have manually populated their NSX-T
+static load balancer pools with the IP addresses of the HA Proxy or Router VMs.
+When upgrading PAS (Pivotal Application Service) from 2.2 to 2.3, applying a
+stemcell update, or updating a tile, the foundation may become unreachable (as
+the NSX-T static load balancer server pools have been emptied). To read more
+about this issue, see [Safely Upgrading PAS 2.2 → 2.3 with NSX-T Load
+Balancers](http://engineering.pivotal.io/post/upgrade_2.2-2.3_on_nsx-t/).
 
-For more information about updating NSX-T server pool membership during an upgrade from Ops Manager v2.2 to Ops Manager v2.3,
-see [Safely Upgrading PAS 2.2 → 2.3 with NSX-T Load Balancers](http://engineering.pivotal.io/post/upgrade_2.2-2.3_on_nsx-t/).
+To implement this procedure, you must use the Ops Manager API. See the [Ops
+Manager API documentation](https://docs.pivotal.io/pivotalcf/2-3/opsman-api) for
+more information about the API.
 
 <p class="note"><strong>Note:</strong> Ops Manager v2.3 supports NSX-T v2.2 and later.</p>
 


### PR DESCRIPTION
We neglected to explain when & why to follow the load balancer server
pool membership update procedure. As a matter of fact, usually it isn't
necessary. We now give a full explanation.

Per Bright Zheng:

> I saw this but can anyone help clarify the purpose of doing this? Any
impact/issue without doing this?

[#162210006](https://www.pivotaltracker.com/story/show/162210006)

Signed-off-by: Josh Russett <jrussett@pivotal.io>

This PR only applies to version `2.3` of the docs and does not need to be backported. 