### PR TITLE
Primary field is required for BOSH Validation

### DIFF
--- a/_credhub.html.md.erb
+++ b/_credhub.html.md.erb
@@ -30,7 +30,7 @@
 	If you have configured an HSM provider and HSM servers above, select **HSM**. Otherwise, select **Internal**.
 	* **Key**. This key is used for encrypting all data. The key must be at least 20 characters long.
 	* **Primary**. This checkbox is used for marking the key you specified above as the primary encryption key.
-		<p class="note"><strong>Note:</strong> Ensure that you mark only one key as <strong>Primary</strong>. For more information about using additional keys for key rotation, see the <a href="../opsguide/credential-rotation.html">Rotating Runtime CredHub Encryption Keys</a> topic.</p>
+		<p class="note"><strong>Note:</strong> Ensure that you mark one (or BOSH validation will fail) and only one key as <strong>Primary</strong>. For more information about using additional keys for key rotation, see the <a href="../opsguide/credential-rotation.html">Rotating Runtime CredHub Encryption Keys</a> topic.</p>
 1. (Optional) To configure CredHub to use an HSM, complete the following fields:
   * **HSM Provider Partition**. This is the name of the HSM provider partition.
   * **HSM Provider Partition Password**. This password is used to access the HSM provider partition.

--- a/_credhub.html.md.erb
+++ b/_credhub.html.md.erb
@@ -29,8 +29,8 @@
 	* **Provider**. This is the provider of the encryption key.
 	If you have configured an HSM provider and HSM servers above, select **HSM**. Otherwise, select **Internal**.
 	* **Key**. This key is used for encrypting all data. The key must be at least 20 characters long.
-	* **Primary**. This checkbox is used for marking the key you specified above as the primary encryption key.
-		<p class="note"><strong>Note:</strong> Ensure that you mark one (or BOSH validation will fail) and only one key as <strong>Primary</strong>. For more information about using additional keys for key rotation, see the <a href="../opsguide/credential-rotation.html">Rotating Runtime CredHub Encryption Keys</a> topic.</p>
+        * **Primary**. This checkbox is used for marking the key you specified above as the primary encryption key. You must mark one key as **Primary** or your deploy will fail. Ensure that you do not mark more than one key as **Primary**. 
+          <p class="note"><strong>Note:</strong> For information about using additional keys for key rotation, see the <a href="../opsguide/credential-rotation.html">Rotating Runtime CredHub Encryption Keys</a> topic.</p>
 1. (Optional) To configure CredHub to use an HSM, complete the following fields:
   * **HSM Provider Partition**. This is the name of the HSM provider partition.
   * **HSM Provider Partition Password**. This password is used to access the HSM provider partition.


### PR DESCRIPTION
My initial install failed until I marked my key as primary. The instructions didn't make it clear that I had to check at least one.