### PR TITLE
Clarify use of AWS LBs

### DIFF
--- a/_networking-master.html.md.erb
+++ b/_networking-master.html.md.erb
@@ -71,7 +71,7 @@
 	<img alt="Http Headers to Log" src="images/headers_to_log.png">
 1. <%= partial 'haproxy_request_max_buffer' %>
 1. <%= partial 'protected_domains' %>
-1. The **Loggregator Port** defaults to `443` if left blank. For AWS deployments, you must set this value to `4443`. 
+1. The **Loggregator Port** defaults to `443` if left blank.
 1. For **Container Network Interface Plugin**, select one of the following:
   * **Silk**: This option is the default Container Network Interface (CNI) for PAS.
   * **External**: Select this if you are deploying the [VMware NSX-T Container Plug-in for PCF](https://network.pivotal.io/products/vmware-nsx-t).

--- a/configure-lb.html.md.erb
+++ b/configure-lb.html.md.erb
@@ -3,28 +3,29 @@ title: Configuring Load Balancing for PAS
 owner: Releng
 ---
 
-This topic describes how to configure load balancing for Pivotal Application Service (PAS) by entering the names of your load balancers in the **Resource Config** pane of the PAS tile. This procedure varies by IaaS an installation method. See the section below that corresponds to your use case. 
+This topic describes how to configure load balancing for Pivotal Application Service (PAS) by entering the names of your load balancers in the **Resource Config** pane of the PAS tile. This procedure varies by IaaS an installation method. See the section below that corresponds to your use case.
 
 ## <a id="aws"></a> AWS
 
 To configure the Gorouter or HAProxy to AWS Elastic Load Balancers, do the following:
 
-1. Record the names of your ELBs. If you followed the procedures in the [Installing PCF on AWS Manually](../om/aws/prepare-env-manual.html) topic, you created the following: 
-  * `pcf-ssh-elb`: A SSH load balancer
-  * `pcf-web-elb`: A web load balancer
-  * `pcf-tcp-elb`: A TCP load balancer
+1. Record the names of your ELBs. If you followed the procedures in the [Installing PCF on AWS Manually](../om/aws/prepare-env-manual.html) topic, you created the following:
+  * `pcf-ssh-elb`: A SSH load balancer (Classic Load Balancer)
+  * `pcf-tcp-elb`: A TCP load balancer (Classic Load Balancer)
+  * `pcf-web-elb`: A web load balancer (Application Load Balancer)
+    * `pcf-web-elb-target-group`: a target group for the web load balancer
 
 1. In the PAS tile, click **Resource Config**.
   <%= image_tag("images/resource_config.png") %>
 
-1. Enter the name of your SSH load balancer depending on which release you are using. You can specify multiple load balancers by entering the names separated by commas.
-  * **PAS**: In the **ELB Name** field of the **Diego Brain** row, enter the name of your SSH load balancer: `pcf-ssh-elb`.
-  * **Small Footprint Runtime**: In the **ELB Name** field of the **Control** row, enter the name of your SSH load balancer: `pcf-ssh-elb`.
+1. Enter the name of your SSH load balancer depending on which release you are using.
+  * **PAS**: In the **Load Balancers** field of the **Diego Brain** row, enter the name of your SSH load balancer: `pcf-ssh-elb`.
+  * **Small Footprint Runtime**: In the **Load Balancers** field of the **Control** row, enter the name of your SSH load balancer: `pcf-ssh-elb`.
 
-1. In the **ELB Name** field of the **Router** row, enter the name of your web load balancer: `pcf-web-elb`. You can specify multiple load balancers by entering the names separated by commas.
-  <p class="note"><strong>Note:</strong> If you are using HAProxy in your deployment, then put the name of the load balancers in the **ELB Name** field of the **HAProxy** row instead of the **Router** row. For a high availability configuration, scale up the HAProxy job to more than one instance.</p>
+1. In the **Load Balancers** field of the **Router** row, enter the name of your web load balancer's target group, prefixed with `alb:`: `alb:pcf-web-elb-target-group`. Pay special attention to the `alb:` prefix.  This prefix indicates to Operations Manager that you entered the name of a target group, and is necssary if you use AWS Applciation Load Balancers (ALBs) or Network Load Balancers (NLBs).  If you are using Clasic Load Balancers then omit the `alb:` prefix and enter the name of the load balancer instead of the name of the target group.
+  <p class="note"><strong>Note:</strong> If you are using HAProxy in your deployment, then put the name of the load balancers in the **Load Balancers** field of the **HAProxy** row instead of the **Router** row. For a high availability configuration, scale up the HAProxy job to more than one instance.</p>
 
-1. In the **ELB Name** field of the **TCP Router** row, enter the name of your TCP load balancer if you enabled TCP routing: `pcf-tcp-elb`. You can specify multiple load balancers by entering the names separated by commas.
+1. In the **Load Balancers** field of the **TCP Router** row, enter the name of your TCP load balancer if you enabled TCP routing: `pcf-tcp-elb`.
 
 ## <a id="aws-terraform"></a> AWS Terraform
 
@@ -33,14 +34,14 @@ To configure the Gorouter or HAProxy to AWS Elastic Load Balancers, do the follo
 1. In the PAS tile, click **Resource Config**.
   <%= image_tag("images/resource_config.png") %>
 
-1. Enter the name of your SSH load balancer depending on which release you are using. You can specify multiple load balancers by entering the names separated by commas.
-  * **Pivotal Application Service (PAS)**: In the **ELB Name** field of the **Diego Brain** row, enter the value of `ssh_elb_name` from the Terraform output.
-  * **Small Footprint Runtime**: In the **ELB Name** field of the **Control** row, enter the value of `ssh_elb_name` from the Terraform output.
+1. Enter the name of your SSH load balancer depending on which release you are using.
+  * **Pivotal Application Service (PAS)**: In the **Load Balancers** field of the **Diego Brain** row, enter the value of `ssh_elb_name` from the Terraform output.
+  * **Small Footprint Runtime**: In the **Load Balancers** field of the **Control** row, enter the value of `ssh_elb_name` from the Terraform output.
 
-1. In the **ELB Name** field of the **Router** row, enter the value of `web_elb_name` from the Terraform output.
-    <p class="note"><strong>Note:</strong> If you are using HAProxy in your deployment, then put the name of the load balancers in the **ELB Name** field of the **HAProxy** row instead of the **Router** row. For a high availability configuration, scale up the HAProxy job to more than one instance.</p>
+1. In the **Load Balancers** field of the **Router** row, enter the value of `web_elb_name` from the Terraform output.
+    <p class="note"><strong>Note:</strong> If you are using HAProxy in your deployment, then put the name of the load balancers in the **Load Balancers** field of the **HAProxy** row instead of the **Router** row. For a high availability configuration, scale up the HAProxy job to more than one instance.</p>
 
-1. In the **ELB Name** field of the **TCP Router** row, enter the value of `tcp_elb_name` from the Terraform output.
+1. In the **Load Balancers** field of the **TCP Router** row, enter the value of `tcp_elb_name` from the Terraform output.
 
 1. Click **Save**.
 
@@ -85,7 +86,7 @@ To configure the Gorouter to Azure Load Balancers, do the following:
 1. Scale the number of instances as appropriate for your deployment.
   <p class="note"><strong>Note:</strong> For a high availability deployment of PCF on Azure, Pivotal recommends scaling the number of each PAS job to a minimum of three (3) instances. Using three or more instances for each job creates a sufficient number of availability sets and fault domains for your deployment. For more information, see <a href="../refarch/azure/azure_ref_arch.html">Reference Architecture for Pivotal Cloud Foundry on Azure</a>.</p>
 
-## <a id="gcp"></a> GCP 
+## <a id="gcp"></a> GCP
 
 To Configure Gorouter to GCP Load Balancers, do the following:
 

--- a/elb-ssh-proxy.html.md.erb
+++ b/elb-ssh-proxy.html.md.erb
@@ -9,7 +9,7 @@ Perform the steps below to create this ELB:
 
 1. On the EC2 Dashboard, click **Load Balancers**.
 
-1. Click **Create Load Balancer**, and configure a load balancer with the following information:
+1. Click **Create Load Balancer**, and configure a classic load balancer with the following information:
 
 	<%= image_tag("aws/aws_ssh_elb_step1.png") %>
   * Enter a load balancer name.
@@ -46,6 +46,6 @@ Perform the steps below to create this ELB:
 
 1. You can now use this ELB to the SSH Proxy of your Pivotal Application Service (PAS) installation.
 
-2. In PAS, select **Resource Config**, and enter the ELB that you just created in the **Diego Brain** row, under the ELB Names column.
+2. In PAS, select **Resource Config**, and enter the ELB that you just created in the **Diego Brain** row, under the Load Balancers column.
 
 	<%= image_tag("aws/aws_ssh_er_diego_brain_config.png") %>


### PR DESCRIPTION
In several cases, the docs are assuming ELB always refers to a Classic ELB, but with the advent of the application load balancers (ALBs) and network load balancers (NLBs) it makes sense to clarify the instructions for each type.

- instruct users to enter the target group name and not the load balancer name in the resource config when using ALB and NLB (and prefix with `alb:`)
- Remove reference to port 4443, as our install instructions recommend ALBs, which support websockets and do not require a separate load balancer on a separate port.  The default
loggregator port of 443 works with ALBs out of the box.
- Correct the name of the load balancer field in Operations Manager's resource config
- Remove mention of supporting multiple load balancers (this doesn't work)