### PR TITLE
Clarify PEM cert chain order.

### DIFF
--- a/_haproxy_router_cert_config.html.md.erb
+++ b/_haproxy_router_cert_config.html.md.erb
@@ -3,9 +3,7 @@ Under **Certificates and Private Key for HAProxy and Router**, you must provide 
    1. Click the **Add** button to add a name for the certificate chain and its private key pair. This certificate is the default used by Gorouter and HAProxy.
     <%= image_tag 'images/networking_haproxy_router_cert_config.png' %>
        You can either provide a certificate signed by a Certificate Authority (CA) or click on the **Generate RSA Certificate** link to generate a self-signed certificate in Ops Manager.
-  <p class="note"><strong>Note</strong>: If you configured Ops Manager Front End without a certificate,
-  you can use this new certificate to complete Ops Manager configuration. To configure your Ops Manager Front End certificate,
-  see <a href="https://docs.pivotal.io/pcf/om/gcp/prepare-env-manual.html#config-frontend">Configure Front End</a>.</p>
+  <p class="note"><strong>Note</strong>: If you configured Ops Manager Front End without a certificate, you can use this new certificate to complete Ops Manager configuration. To configure your Ops Manager Front End certificate, see <a href="https://docs.pivotal.io/pcf/om/gcp/prepare-env-manual.html#config-frontend">Configure Front End</a>.</p>
   1. If you want to configure multiple certificates for HAProxy and Gorouter, click the **Add** button and fill in the appropriate fields for each additional certificate key pair.
   For details about generating certificates in Ops Manager for your wildcard system domains, see the <a href="../opsguide/security_config.html#config">Providing a Certificate for Your SSL/TLS Termination Point</a> topic.
   <p class="note"><strong>Note:</strong> Ensure that you add any certificates that you generate in this pane to your infrastructure load balancer.</p>

--- a/_haproxy_router_cert_config.html.md.erb
+++ b/_haproxy_router_cert_config.html.md.erb
@@ -1,6 +1,5 @@
 Under **Certificates and Private Key for HAProxy and Router**, you must provide at least one **Certificate and Private Key** name and certificate key pair for HAProxy and Gorouter. HAProxy and Gorouter are enabled to receive TLS communication by default. You can configure multiple certificates for HAProxy and Gorouter.
-  <p class="note"><strong>Note:</strong> When providing custom certificates, enter them in the following order: <code>wildcard</code>, <code>Intermediate</code>, <code>CA</code>. For more information, see <a href="https://www.digicert.com/ssl-support/pem-ssl-creation.htm">Creating a .pem File for SSL Certificate Installations
-</a> in the DigiCert documentation.</p>
+  <p class="note"><strong>Note:</strong> When providing custom certificates, enter them in the following order: <code>wildcard</code>, <code>Intermediate</code>, <code>CA</code>. For more information, see <a href="https://www.digicert.com/ssl-support/pem-ssl-creation.htm">Creating a .pem File for SSL Certificate Installations</a> in the DigiCert documentation.</p>
    1. Click the **Add** button to add a name for the certificate chain and its private key pair. This certificate is the default used by Gorouter and HAProxy.
     <%= image_tag 'images/networking_haproxy_router_cert_config.png' %>
        You can either provide a certificate signed by a Certificate Authority (CA) or click on the **Generate RSA Certificate** link to generate a self-signed certificate in Ops Manager.

--- a/_haproxy_router_cert_config.html.md.erb
+++ b/_haproxy_router_cert_config.html.md.erb
@@ -1,5 +1,6 @@
-Under **Certificates and Private Key for HAProxy and Router**, you must provide at least one **Certificate and Private Key** name and certificate key pair for HAProxy and Gorouter. The HAProxy and Gorouter are enabled to receive TLS communication by default. You can configure multiple certificates for HAProxy and Gorouter.
-  <p class="note"><strong>Note</strong>: When providing custom certificates, enter them in the following order: wildcard > Intermediate > CA (paste top to bottom). <a href="https://www.digicert.com/ssl-support/pem-ssl-creation.htm">Additional reference.</a></p>
+Under **Certificates and Private Key for HAProxy and Router**, you must provide at least one **Certificate and Private Key** name and certificate key pair for HAProxy and Gorouter. HAProxy and Gorouter are enabled to receive TLS communication by default. You can configure multiple certificates for HAProxy and Gorouter.
+  <p class="note"><strong>Note:</strong> When providing custom certificates, enter them in the following order: <code>wildcard</code>, <code>Intermediate</code>, <code>CA</code>. For more information, see <a href="https://www.digicert.com/ssl-support/pem-ssl-creation.htm">Creating a .pem File for SSL Certificate Installations
+</a> in the DigiCert documentation.</p>
    1. Click the **Add** button to add a name for the certificate chain and its private key pair. This certificate is the default used by Gorouter and HAProxy.
     <%= image_tag 'images/networking_haproxy_router_cert_config.png' %>
        You can either provide a certificate signed by a Certificate Authority (CA) or click on the **Generate RSA Certificate** link to generate a self-signed certificate in Ops Manager.
@@ -8,4 +9,4 @@ Under **Certificates and Private Key for HAProxy and Router**, you must provide 
   see <a href="https://docs.pivotal.io/pcf/om/gcp/prepare-env-manual.html#config-frontend">Configure Front End</a>.</p>
   1. If you want to configure multiple certificates for HAProxy and Gorouter, click the **Add** button and fill in the appropriate fields for each additional certificate key pair.
   For details about generating certificates in Ops Manager for your wildcard system domains, see the <a href="../opsguide/security_config.html#config">Providing a Certificate for Your SSL/TLS Termination Point</a> topic.
-  <p class="note"><strong>Note</strong>: Ensure that you add any certificates that you generate in this pane to your infrastructure load balancer.</p>
+  <p class="note"><strong>Note:</strong> Ensure that you add any certificates that you generate in this pane to your infrastructure load balancer.</p>

--- a/_haproxy_router_cert_config.html.md.erb
+++ b/_haproxy_router_cert_config.html.md.erb
@@ -1,10 +1,11 @@
-Under **Certificates and Private Key for HAProxy and Router**, you must provide at least one **Certificate and Private Key** name and certificate key pair for HAProxy and Gorouter. The HAProxy and Gorouter are enabled to receive TLS communication by default. You can configure multiple certificates for HAProxy and Gorouter. 
+Under **Certificates and Private Key for HAProxy and Router**, you must provide at least one **Certificate and Private Key** name and certificate key pair for HAProxy and Gorouter. The HAProxy and Gorouter are enabled to receive TLS communication by default. You can configure multiple certificates for HAProxy and Gorouter.
+  <p class="note"><strong>Note</strong>: When providing custom certificates, enter them in the following order: wildcard > Intermediate > CA (paste top to bottom). <a href="https://www.digicert.com/ssl-support/pem-ssl-creation.htm">Additional reference.</a></p>
    1. Click the **Add** button to add a name for the certificate chain and its private key pair. This certificate is the default used by Gorouter and HAProxy.
     <%= image_tag 'images/networking_haproxy_router_cert_config.png' %>
        You can either provide a certificate signed by a Certificate Authority (CA) or click on the **Generate RSA Certificate** link to generate a self-signed certificate in Ops Manager.
-  <p class="note"><strong>Note</strong>: If you configured Ops Manager Front End without a certificate, 
-  you can use this new certificate to complete Ops Manager configuration. To configure your Ops Manager Front End certificate, 
+  <p class="note"><strong>Note</strong>: If you configured Ops Manager Front End without a certificate,
+  you can use this new certificate to complete Ops Manager configuration. To configure your Ops Manager Front End certificate,
   see <a href="https://docs.pivotal.io/pcf/om/gcp/prepare-env-manual.html#config-frontend">Configure Front End</a>.</p>
-  1. If you want to configure multiple certificates for HAProxy and Gorouter, click the **Add** button and fill in the appropriate fields for each additional certificate key pair.  
+  1. If you want to configure multiple certificates for HAProxy and Gorouter, click the **Add** button and fill in the appropriate fields for each additional certificate key pair.
   For details about generating certificates in Ops Manager for your wildcard system domains, see the <a href="../opsguide/security_config.html#config">Providing a Certificate for Your SSL/TLS Termination Point</a> topic.
   <p class="note"><strong>Note</strong>: Ensure that you add any certificates that you generate in this pane to your infrastructure load balancer.</p>


### PR DESCRIPTION
Added note box to help clarify proper order for pem cert chains.  Feel free to reformat, remove external link, etc -- main goal is saving future readers time remembering/looking up proper cert chain order.  :-)

Co-authored-by: Arron Hocking <ahocking@pivotal.io>
Co-authored-by: Rahul Jain <rahul@pivotal.io>
Co-authored-by: Shwan Neil <sneal@pivotal.io>