### PR TITLE
Add NLB attachment instructions for PAS on AWS with Terraform

### DIFF
--- a/aws-er-config-terraform.html.md.erb
+++ b/aws-er-config-terraform.html.md.erb
@@ -251,17 +251,33 @@ For additional factors to consider when selecting file storage, see the [Conside
 
 ## <a id='config-elb'></a> Step 23: Configure Router (or HAProxy) to Elastic Load Balancer
 
+According to the patch version of PAS you are using, the Terraform config may deploy either **Network Load Balancers** or **Classic Load Balancers**. The entries in your Terraform output indicate which you have:
+ * Entries with the suffix `target_group` mean Network Load Balancers are deployed. This is the case for the most recent releases.
+ * Entries with the suffix `elb_name` mean Classic Load Balancers are deployed. This was the case for previous releases.
+
+This affects the configuration you need to do for each Load Balancer:
+ * **Network Load Balancer**: You will need to configure your VMs to attach to the **target group**. The value in the Ops Manager config should look like `alb:target_group_name`. The prefix indicates to Ops Manager that you entered the name of a target group, and is required for AWS Application Load Balancers or Network Load Balancers.
+ * **Classic Load Balancer**: You will configure VMs to attach to the Load Balancer directly. The value in the Ops Manager config should just be the load balancer name.
+
 1. In the PAS tile, click **Resource Config**.
   <%= image_tag("images/resource_config.png") %>
+  
+1. For the SSH Load Balancer, fill the **Load Balancers** field with one of the following:
+  * **Network Load Balancer**: The values of `ssh_target_groups` from the Terraform output, prefixed with "alb:": `alb:pcf-ssh-tg`. 
+  * **Classic Load Balancer**: The value of `ssh_elb_name` from the Terraform output.
 
-1. Enter the name of your SSH load balancer depending on which release you are using. 
-  * **Pivotal Application Service (PAS)**: In the **Load Balancers** field of the **Diego Brain** row, enter the value of `ssh_elb_name` from the Terraform output.
-  * **Small Footprint Runtime**: In the **Load Balancers** field of the **Control** row, enter the value of `ssh_elb_name` from the Terraform output.
+   The row you should fill in depends on the release you are using:
+   * **Pivotal Application Service (PAS)**: Enter your value in the **Load Balancers** field of the **Diego Brain** row.
+   * **Small Footprint Runtime**: Enter your value in the **Load Balancers** field of the **Control** row.
 
-1. In the **Load Balancers** field of the **Router** row, enter the value of `web_elb_name` from the Terraform output.
-    <p class="note"><strong>Note:</strong> If you are using HAProxy in your deployment, then put the name of the load balancers in the **Load Balancers** field of the **HAProxy** row instead of the **Router** row. For a high availability configuration, scale up the HAProxy job to more than one instance.</p>
+1. Fill the **Load Balancers** field of the **Router** row with one of the following: 
+  * **Network Load Balancer**: All values of `web_target_groups` from the Terraform output, prefixed with "alb:": `alb:pcf-web-tg-80,alb:pcf-web-tg-443`. 
+  * **Classic Load Balancer**: The value of `web_elb_name` from the Terraform output.
+    <p class="note"><strong>Note:</strong> If you are using HAProxy in your deployment, then put the value in the **Load Balancers** field of the **HAProxy** row instead of the **Router** row. For a high availability configuration, scale up the HAProxy job to more than one instance.</p>
 
-1. In the **Load Balancers** field of the **TCP Router** row, enter the value of `tcp_elb_name` from the Terraform output.
+1. In the **Load Balancers** field of the **TCP Router** row, enter one of the following:
+  * **Network Load Balancer**: All values of `tcp_target_groups` from the Terraform output, prefixed with "alb:": `alb:default-tg-1024,alb:default-tg-1024`. 
+  * **Classic Load Balancer**: The value of `tcp_elb_name` from the Terraform output.
 
 1. Click **Save**.
 


### PR DESCRIPTION
While the manual install docs got updated recently, these docs only refer to classic load balancers. The changes here only relate to the attachment of load balancers to VMs (not sure if there's anywhere else that needs updated??).

Since different versions of PAS 2.4.x contain different Terraform configs it looks like we also need to keep the instructions for classic load balancers - so I've done my best to clarify the instructions for each.