### PR TITLE
Link to deploying PCF page rather than listing the IaaS specific pages

### DIFF
--- a/backup-restore/backup-pcf-bbr.html.md.erb
+++ b/backup-restore/backup-pcf-bbr.html.md.erb
@@ -642,12 +642,7 @@ To spin up a second environment that matches the original in order to test a res
 
 1. Export your Ops Manager installation by performing the steps in the [Step 8: Export Installation Settings](#export) section.
 
-1. Create a new Ops Manager VM in a different network to the original. Ensure that the Ops Manager VM has enough persistent disk to accommodate the files exported in the previous step. Consult the topic specific to your IaaS:
-  * [Deploying BOSH and Ops Manager to AWS](../aws-terraform.html)
-  * [Configuring AWS for PCF](../../om/aws/prepare-env-manual.html)
-  * [Deploying Ops Manager on GCP Manually](../../om/gcp/deploy-manual.html)
-  * [Provisioning the OpenStack Infrastructure](../../om/openstack/setup.html)
-  * [Deploying Operations Manager to vSphere](../../om/vsphere/deploy.html)
+1. Create a new Ops Manager VM in a different network to the original. Ensure that the Ops Manager VM has enough persistent disk to accommodate the files exported in the previous step. Consult the topic for [deploying PCF on your IaaS](../deploy-bosh-om.html#contents).
 
 After you deploy the second environment, follow the instructions in the [Restoring Pivotal Cloud Foundry from Backup with BBR](restore-pcf-bbr.html) topic.
 


### PR DESCRIPTION
PCF users should not be misled to believe that BBR does not support Azure when reading the backup validation docs. [#163618062](https://www.pivotaltracker.com/story/show/163618062)

The Azure link was removed from this list of links by mistake.

This change avoids maintaining a list of links for every IaaS in favour of linking to the list in the Installing PCF section.

Please could this change be backported to PCF 2.4, 2.3 and 2.2.

Jake and @jamesjoshuahill 