### PR TITLE
Terraform ELBs are network load balancers now

### DIFF
--- a/aws-er-config-terraform.html.md.erb
+++ b/aws-er-config-terraform.html.md.erb
@@ -249,19 +249,19 @@ For additional factors to consider when selecting file storage, see the [Conside
 
 <%= partial 'errands' %>
 
-## <a id='config-elb'></a> Step 23: Configure Router (or HAProxy) to Elastic Load Balancer
+## <a id='config-elb'></a> Step 23: Configure Router (or HAProxy), Diego Brain, and TCP router to Elastic Load Balancer
 
 1. In the PAS tile, click **Resource Config**.
   <%= image_tag("images/resource_config.png") %>
 
 1. Enter the name of your SSH load balancer depending on which release you are using. 
-  * **Pivotal Application Service (PAS)**: In the **Load Balancers** field of the **Diego Brain** row, enter the value of `ssh_elb_name` from the Terraform output.
-  * **Small Footprint Runtime**: In the **Load Balancers** field of the **Control** row, enter the value of `ssh_elb_name` from the Terraform output.
+  * **Pivotal Application Service (PAS)**: In the **Load Balancers** field of the **Diego Brain** row, enter the value of `ssh_target_groups` from the Terraform output. You will need to to prepend alb: in front of the value. For example if the value in `ssh_target_groups` is `aws-pcf-ssh-tg` you should put `alb:aws-pcf-ssh-tg` in the resource config box.
+  * **Small Footprint Runtime**: In the **Load Balancers** field of the **Control** row, enter the value of `ssh_target_groups` from the Terraform output. You will need to to prepend alb: in front of the value. For example if the value in `ssh_target_groups` is `aws-pcf-ssh-tg` you should put `alb:aws-pcf-ssh-tg` in the resource config box.
 
-1. In the **Load Balancers** field of the **Router** row, enter the value of `web_elb_name` from the Terraform output.
+1. In the **Load Balancers** field of the **Router** row, enter the value of `web_target_groups` from the Terraform output. You will need to to prepend alb: in front of the values. For example if the values in `web_target_groups` are `aws-pcf-web-tg-80, aws-pcf-web-tg-443` you should put `alb:aws-pcf-web-tg-80, alb:aws-pcf-web-tg-443` in the resource config box.
     <p class="note"><strong>Note:</strong> If you are using HAProxy in your deployment, then put the name of the load balancers in the **Load Balancers** field of the **HAProxy** row instead of the **Router** row. For a high availability configuration, scale up the HAProxy job to more than one instance.</p>
 
-1. In the **Load Balancers** field of the **TCP Router** row, enter the value of `tcp_elb_name` from the Terraform output.
+1. In the **Load Balancers** field of the **TCP Router** row, enter the values of `tcp_target_groups` from the Terraform output. You will need to to prepend alb: in front of the values. For example if the values in `tcp_target_groups` are `aws-pcf-tg-1029, aws-pcf-tg-1030, aws-pcf-tg-1031, aws-pcf-tg-1032, aws-pcf-tg-1033` you should put `alb:aws-pcf-tg-1029, alb:aws-pcf-tg-1030, alb:aws-pcf-tg-1031, alb:aws-pcf-tg-1032, alb:aws-pcf-tg-1033` in the resource config box.
 
 1. Click **Save**.
 


### PR DESCRIPTION
Pivotal Terrafrorm creates network load balancers for router, tcp router, and diego brain now and the documentation still had instructions for the old classic load balancers. 