### PR TITLE
fixing curl miss

### DIFF
--- a/update-nsx-t.html.md.erb
+++ b/update-nsx-t.html.md.erb
@@ -97,7 +97,7 @@ To stage and associate VM extensions with the load balancer, do the following:
 1. Run the following command to stage the `web.json` VM extension:
 
 	```
-	curl "https://OPS-MAN-FQDN/api/v0/staged/vm_extensions" \
+	curl "<span>http</span>s://OPS-MAN-FQDN/api/v0/staged/vm_extensions" \
 	-X POST \
 	-H "Authorization: Bearer UAA-ACCESS-TOKEN" \
 	-H "Content-Type: application/json" \
@@ -113,7 +113,7 @@ To stage and associate VM extensions with the load balancer, do the following:
 1. Run the following command to retrieve a list of staged products:
 
 	```
-	curl 'https://OPS-MAN-FQDN/api/v0/staged/products' \
+	curl '<span>http</span>s://OPS-MAN-FQDN/api/v0/staged/products' \
 	-H "Authorization: Bearer UAA-ACCESS-TOKEN"
 	```
 
@@ -137,7 +137,7 @@ To stage and associate VM extensions with the load balancer, do the following:
 1. Retrieve the list of jobs for `cf`:
 	
 	```
-	curl 'https://OPS-MAN-FQDN/api/v0/staged/products/PRODUCT-GUID/jobs' \
+	curl '<span>http</span>s://OPS-MAN-FQDN/api/v0/staged/products/PRODUCT-GUID/jobs' \
 	-H 'Authorization: Bearer UAA-ACCESS-TOKEN'
 	```
 

--- a/update-nsx-t.html.md.erb
+++ b/update-nsx-t.html.md.erb
@@ -97,7 +97,7 @@ To stage and associate VM extensions with the load balancer, do the following:
 1. Run the following command to stage the `web.json` VM extension:
 
 	```
-	curl "https://OPS-MAN-FQDN/api/v0/staged/vm_extensions' \
+	curl "https://OPS-MAN-FQDN/api/v0/staged/vm_extensions" \
 	-X POST \
 	-H "Authorization: Bearer UAA-ACCESS-TOKEN" \
 	-H "Content-Type: application/json" \
@@ -113,7 +113,7 @@ To stage and associate VM extensions with the load balancer, do the following:
 1. Run the following command to retrieve a list of staged products:
 
 	```
-	curl 'http<span>s</span>://OPS-MAN-FQDN/api/v0/staged/products' \
+	curl 'https://OPS-MAN-FQDN/api/v0/staged/products' \
 	-H "Authorization: Bearer UAA-ACCESS-TOKEN"
 	```
 
@@ -137,7 +137,7 @@ To stage and associate VM extensions with the load balancer, do the following:
 1. Retrieve the list of jobs for `cf`:
 	
 	```
-	curl 'http<span>s</span>://OPS-MAN-FQDN/api/v0/staged/products/PRODUCT-GUID/jobs' \
+	curl 'https://OPS-MAN-FQDN/api/v0/staged/products/PRODUCT-GUID/jobs' \
 	-H 'Authorization: Bearer UAA-ACCESS-TOKEN'
 	```
 
@@ -178,7 +178,7 @@ To stage and associate VM extensions with the load balancer, do the following:
       * `JOB-GUID` is the GUID you recorded for the `router` job.
       * `INSTANCE-TYPE` is the instance type for the job. For the default instance type, use `"automatic"`.
       * `INSTANCE-COUNT` is the number of instances for the job. The default number for each job is visible in the Resource Config section of the Ops Manager UI.
-      * `VM-EXTENSION-NAME` is `web`. 
+      * `VM-EXTENSION-NAME` is `pcf_web_vm_extension`. 
 
 
 
@@ -186,13 +186,13 @@ To stage and associate VM extensions with the load balancer, do the following:
    
     Where:
     - `JOB-GUID` is the GUID you recorded for the `tcp_router` job.
-    - `VM-EXTENSION-NAME` is `tcp`.
+    - `VM-EXTENSION-NAME` is `pcf_tcp_vm_extension`.
 
 2. Run the previous command again.
 
     Where:
     - `JOB-GUID` is the GUID you recorded for the `diego_brain` job.
-    - `VM-EXTENSION-NAME` is `ssh`.
+    - `VM-EXTENSION-NAME` is `pcf_ssh_vm_extension`.
 
 ### <a id="apply-changes"></a> Apply Changes
 


### PR DESCRIPTION
Fixing the different quotation marks in the curl statements. They prevented the commands from execution. 

Fixed the referenced of the VM-EXTENSION-NAMES. Different names were used throughout the document