### PR TITLE
NSX-T: Ensure consistent naming for VM Extensions

### DIFF
--- a/update-nsx-t.html.md.erb
+++ b/update-nsx-t.html.md.erb
@@ -178,7 +178,7 @@ curl "https://OPS-MAN-FQDN/api/v0/staged/products/PRODUCT-GUID/jobs/JOB-GUID/res
       * `JOB-GUID` is the GUID you recorded for the `router` job.
       * `INSTANCE-TYPE` is the instance type for the job. For the default instance type, use `"automatic"`.
       * `INSTANCE-COUNT` is the number of instances for the job. The default number for each job is visible in the Resource Config section of the Ops Manager UI.
-      * `VM-EXTENSION-NAME` is `pcf_web_vm_extension`. 
+      * `VM-EXTENSION-NAME` is `pas_web_vm_extension`.
 
 
 
@@ -186,13 +186,13 @@ curl "https://OPS-MAN-FQDN/api/v0/staged/products/PRODUCT-GUID/jobs/JOB-GUID/res
    
     Where:
     - `JOB-GUID` is the GUID you recorded for the `tcp_router` job.
-    - `VM-EXTENSION-NAME` is `pcf_tcp_vm_extension`.
+    - `VM-EXTENSION-NAME` is `pas_tcp_vm_extension`.
 
 2. Run the previous command again.
 
     Where:
     - `JOB-GUID` is the GUID you recorded for the `diego_brain` job.
-    - `VM-EXTENSION-NAME` is `pcf_ssh_vm_extension`.
+    - `VM-EXTENSION-NAME` is `pas_ssh_vm_extension`.
 
 ### <a id="apply-changes"></a> Apply Changes
 


### PR DESCRIPTION
Previously some extensions were prefixed with `pcf-`, now they are consistently prefixed with `pas-`.

Previous PR which first changed from `pcf-` to `pas-`: https://github.com/pivotal-cf/docs-pcf-install/pull/589

This should be **backported to 2.5, 2.4.**

Kudos to Muni Chada for noticing: https://pivotal.slack.com/archives/C055V2M0H/p1556661782060500