### PR TITLE
Updated Prerequisites

### DIFF
--- a/vsphere-nsx-t.html.md.erb
+++ b/vsphere-nsx-t.html.md.erb
@@ -10,7 +10,7 @@ This topic describes how to install Pivotal Application Service (PAS) on vSphere
 
 ## <a id='introduction'></a> Overview
 
-PAS v2.4 uses a Container Network Interface (CNI) plugin to support secure and direct internal communication between containers. This plugin can be:
+PAS uses a Container Network Interface (CNI) plugin to support secure and direct internal communication between containers. This plugin can be:
 
 * The internal Silk plugin that comes packaged with PAS, or
 * On vSphere, [VMware NSX-T Container Plug-in for PCF](https://network.pivotal.io/products/vmware-nsx-t), which installs as an Ops Manager tile.
@@ -20,8 +20,8 @@ PAS v2.4 uses a Container Network Interface (CNI) plugin to support secure and d
 
 Before deploying PAS with NSX-T networking, you must have the following:
 
-* An NSX-T 2.2 or later environment with NSX-T components installed and configured. See the [NSX-T Cookbook](https://docs.google.com/document/d/1hw7USpyMZpKoT5MvSaP9NcnTHsdvMd_w0EGZ19cL8nQ) for directions.
-* BOSH and Ops Manager v2.3 or later installed and configured on vSphere. See [Deploying Ops Manager on vSphere](../om/vsphere/deploy.html) and [Configuring BOSH Director on vSphere](../om/vsphere/config.html).
+* An NSX-T environment with NSX-T components installed and configured. The NSX-T version should support the versions of NCP and PAS you intend to use. See the [Support Matrix](https://pas-nsx-t.cfapps.io/) for relevant supported version combinations and see the [VMware Documentation](https://docs.vmware.com/en/VMware-NSX-T-Data-Center/2.4/installation/GUID-3E0C4CEC-D593-4395-84C4-150CD6285963.html) for NSX-T installation instructions.
+* BOSH and Ops Manager installed and configured on vSphere. See [Deploying Ops Manager on vSphere](../om/vsphere/deploy.html) and [Configuring BOSH Director on vSphere](../om/vsphere/config.html).
 * The [VMware NSX-T Container Plug-in for PCF tile](https://network.pivotal.io/products/vmware-nsx-t) downloaded from Pivotal Network and imported to the Ops Manager **Installation Dashboard**. See [Adding and Importing Products](./add-delete.html#add-import) for how to download and import Pivotal products to the **Installation Dashboard**.
 * The [PAS tile](https://network.pivotal.io/products/elastic-runtime) downloaded from Pivotal Network and imported to the Ops Manager **Installation Dashboard**. The PAS tile must be in one of the following two states:
   * Not deployed yet; you have not yet clicked **Review Pending Changes**, then **Apply Changes** on this version of PAS.


### PR DESCRIPTION
Removed reference to the cookbook which is severely outdated (NSX 2.2) and is now causing problems in the field as it contains steps that no longer need to be performed, that create issues if they *are* performed.

Replaced with link to NSX-T/NCP/PAS support matrix site and link to VMware's NSX-T installation instructions.

Updated general wording of line to be non-version specific, since the versions mentioned were old.

Updated BOSH/Ops Manager line to remove version, since it was also old - PAS 2.5 mandates Ops Manager 2.5 for installation to be possible so do we need to specify (and update/forget to update) the version in this doc each time?

Same for mention of PAS version near the beginning.