### PR TITLE
Remove bbr credhub warning

### DIFF
--- a/backup-restore/restore-pcf-bbr.html.md.erb
+++ b/backup-restore/restore-pcf-bbr.html.md.erb
@@ -13,8 +13,6 @@ The procedures described in this topic prepare your environment for PCF, deploy 
 
 <p class="note warning"><strong>WARNING:</strong> When validating your backup, the VMs and disks from the backed-up BOSH Director should not be visible to the new BOSH Director. As a result, Pivotal recommends that you deploy the new BOSH Director to a different IaaS network and account than the VMs and disks of the backed up BOSH Director.</p>
 
-<p class="note warning"><strong>WARNING:</strong> For PCF v2.0, BBR only supports backup and restore of environments with zero or one CredHub instances.</p>
-
 <p class="note"><strong>Note:</strong> If the BOSH Director you are restoring had any deployments that were deployed manually rather than through an Ops Manager tile, you must restore them manually at the end of the process. For more information, see <a href="#non-tiles">(Optional) Step 16: Restore Non-Tile Deployments</a>.</p>
 
 


### PR DESCRIPTION
This warning is no longer needed.

Can you please port this change in 2.2+ doc branches as well? Thanks!

cc @gmrodgers 