### PR TITLE
Clarify the uaac token owner get step

### DIFF
--- a/opsman-users.html.md.erb
+++ b/opsman-users.html.md.erb
@@ -36,14 +36,16 @@ To add Ops Manager users, do the following:
 <pre class='terminal'>uaac token owner get
   Client ID: opsman
   Client Secret:
-  Username: Admin
-  Password: *******
+  Username: OPSMANAGER-ADMIN-USERNAME
+  Password: OPSMANAGER-ADMIN-PASSWORD
   &nbsp;
   Successfully fetched token via client credentials grant.
   Target <span>https</span>://YOUR-OPSMANAGER-FQDN/uaa/
 </pre>
  Where:
  * `YOUR-OPSMANAGER-FQDN` is the fully qualified domain name of your Ops Manager installation.
+ * `OPSMANAGER-ADMIN-USERNAME` and `OPSMANAGER-ADMIN-PASSWORD` are the username and password respectively for the opsmanager admin user.
+ Note: The Client Secret is left blank.
 1. Add a user.
 <pre>uaac user add USER-NAME -p USER-PASSWORD --emails USER-EMAIL<span>@</span>EXAMPLE.COM</pre>
  Where: 
@@ -63,14 +65,16 @@ To remove Ops Manager users, do the following:
   uaac token owner get
   Client ID: opsman
   Client Secret:
-  Username: Admin
-  Password: *******
+  Username: OPSMANAGER-ADMIN-USERNAME
+  Password: OPSMANAGER-ADMIN-PASSWORD
   &nbsp;
   Successfully fetched token via client credentials grant.
   Target <span>https</span>://YOUR-OPSMAN-FQDN/uaa/
 </pre>
  Where:
  * `YOUR-OPSMANAGER-FQDN` is the fully qualified domain name of your Ops Manager installation.
+ * `OPSMANAGER-ADMIN-USERNAME` and `OPSMANAGER-ADMIN-PASSWORD` are the username and password respectively for the opsmanager admin user.
+ Note: The Client Secret is left blank.
 1. Delete a user:
 <pre>uaac user delete USER-NAME</pre>
  Where:


### PR DESCRIPTION
This change comes from feedback of a partner engineer who found the token retrieval instructions somewhat ambiguous.