### PR TITLE
Update list of supported OpenStack releases

### DIFF
--- a/openstack.html.md.erb
+++ b/openstack.html.md.erb
@@ -33,7 +33,7 @@ This section describes the requirements for installing PCF on OpenStack, includi
 
 The following are OpenStack requirements for deploying PCF: 
 
-* PCF is supported on the OpenStack Liberty, Mitaka, and Newton releases. OpenStack is a collection of inter-operable components and requires general OpenStack expertise to troubleshoot issues that may occur when installing Pivotal Cloud Foundry on particular releases and distributions. To verify that your OpenStack platform is compatible with PCF, use the OpenStack Validator tool. To access the OpenStack Validator tool, see [CF OpenStack Validator](https://github.com/cloudfoundry-incubator/cf-openstack-validator) on GitHub.
+* PCF is supported on the OpenStack Ocata, Pike, Queens, Rocky, and Stein releases. OpenStack is a collection of inter-operable components and requires general OpenStack expertise to troubleshoot issues that may occur when installing Pivotal Cloud Foundry on particular releases and distributions. To verify that your OpenStack platform is compatible with PCF, use the OpenStack Validator tool. To access the OpenStack Validator tool, see [CF OpenStack Validator](https://github.com/cloudfoundry-incubator/cf-openstack-validator) on GitHub.
 
 * Pivotal recommends granting complete access to the OpenStack logs to the operator managing the PCF installation process.
 


### PR DESCRIPTION
Instead of referencing the unsupported releases Liberty, Mitaka, and Newton of OpenStack, we (OpsManager team) would to like to update them for PCF 2.2 onwards to reference the supported releases Ocata, Pike, Queens, Rocky, and Stein.

Our team can submit more PRs for `2.3`, `2.4`, 2.5` and `master` or if you'd prefer to handle those changes, that works for us as well.

