### PR TITLE
Add GCS blobstore backup support in 2.6+

### DIFF
--- a/_filestore_gcp_config.html.md.erb
+++ b/_filestore_gcp_config.html.md.erb
@@ -27,10 +27,11 @@ PAS can use Google Cloud Storage (GCS) as its external filestore by using either
    1. For **GCP Project ID** enter the Project ID on your GCP Console that you want to use for your PAS file storage.
    1. For **GCP Service Account Email** enter the email address associated with your GCP account.
    1. For **GCP Service Account JSON** enter the account key that you use to access the specified GCP project, in JSON format.
-   1. Enter the names of the storage buckets you created in [Preparing to Deploy Ops Manager on GCP Manually](../om/gcp/prepare-env-manual.html#dbs):
+   1. Enter the names of the storage buckets you created in [Preparing to Deploy Ops Manager on GCP Manually](../om/gcp/prepare-env-manual.html#buckets):
       * **Buildpacks Bucket Name**: `MY-PCF-buildpacks`
       * **Droplets Bucket Name**: `MY-PCF-droplets`
       * **Resources Bucket Name**: `MY-PCF-resources`
       * **Packages Bucket Name**: `MY-PCF-packages`
+      * **Backup Bucket Name**: `MY-PCF-backup`
    1. Click **Save**.
 

--- a/_filestore_gcp_config_terraform.html.md.erb
+++ b/_filestore_gcp_config_terraform.html.md.erb
@@ -32,4 +32,5 @@ PAS can use Google Cloud Storage (GCS) as its external filestore by using either
       * **Droplets Bucket Name**: Enter the value of `droplets_bucket` from your Terraform output.
       * **Resources Bucket Name**: Enter the value of `packages_bucket` from your Terraform output.
       * **Packages Bucket Name**: Enter the value of `resources_bucket` from your Terraform output.
+      * **Backup Bucket Name**: Enter the value of `backup_bucket` from your Terraform output.
    1. Click **Save**.

--- a/backup-restore/backup-pcf-bbr.html.md.erb
+++ b/backup-restore/backup-pcf-bbr.html.md.erb
@@ -161,7 +161,7 @@ restore with BBR.
     <td class="cell peach">No</td>
     <td class="cell peach">No</td>
     <td class="cell peach">No</td>
-    <td class="cell peach">No</td>
+    <td class="cell green">Yes</td>
   </tr>
   <tr>
     <td style="color: black;">BOSH Director with GCS Blobstore</td>

--- a/backup-restore/enabling-external-blobstore-backups.html.md.erb
+++ b/backup-restore/enabling-external-blobstore-backups.html.md.erb
@@ -35,40 +35,44 @@ Refer to the table below to determine if external blobstore support is included 
     <th colspan="7" style="border-top-style: hidden; text-align: center; background-color: white; color: black; padding: 10px;">Ops Manager Version</th>
     <th style="border-top-style: hidden; border-right-style: hidden; border-left-style: hidden; border-bottom-style: hidden; background-color: white; "></th>
   <tr>
-    <th class="rotate" rowspan="4" style="width: 5%; border-left-style: hidden; background-color: white; color: black;"><div>Blobstore Type</div></th>
+    <th class="rotate" rowspan="5" style="width: 5%; border-left-style: hidden; background-color: white; color: black;"><div>Blobstore Type</div></th>
     <th style="background-color: #1b786e; color: white;"</th>
-    <th class="cell header" style="width: 14%; text-align: center;">1.11</th>
-    <th class="cell header" style="width: 14%; text-align: center;">1.12</th>
-    <th class="cell header" style="width: 14%; text-align: center;">2.0</th>
-    <th class="cell header" style="width: 14%; text-align: center;">2.1</th>
     <th class="cell header" style="width: 14%; text-align: center;">2.2</th>
-    <th class="cell header" style="width: 14%; text-align: center;">2.3+</th>
+    <th class="cell header" style="width: 14%; text-align: center;">2.3</th>
+    <th class="cell header" style="width: 14%; text-align: center;">2.4</th>
+    <th class="cell header" style="width: 14%; text-align: center;">2.5</th>
+    <th class="cell header" style="width: 14%; text-align: center;">2.6</th>
   </tr>
   <tr>
     <td style="color: black;">Versioned</td>
-    <td class="cell peach">Add-On</td>
-    <td class="cell peach">Add-On</td>
-    <td class="cell peach">Add-On</td>
+    <td class="cell green">Included</td>
+    <td class="cell green">Included</td>
     <td class="cell green">Included</td>
     <td class="cell green">Included</td>
     <td class="cell green">Included</td>
   </tr>
   <tr>
     <td style="color: black;">Unversioned</td>
-    <td class="cell peach">Add-On</td>
-    <td class="cell peach">Add-On</td>
-    <td class="cell peach">Add-On</td>
-    <td class="cell peach">Add-On</td>
+    <td class="cell green">Included</td>
+    <td class="cell green">Included</td>
+    <td class="cell green">Included</td>
     <td class="cell green">Included</td>
     <td class="cell green">Included</td>
   </tr>
   <tr>
-    <td style="color: black;">Azure</sup></td>
-    <td class="cell peach">Add-On</td>
-    <td class="cell peach">Add-On</td>
-    <td class="cell peach">Add-On</td>
-    <td class="cell peach">Add-On</td>
-    <td class="cell peach">Add-On</td>
+    <td style="color: black;">Azure</td>
+    <td class="cell pale-green">Add-On</td>
+    <td class="cell green">Included</td>
+    <td class="cell green">Included</td>
+    <td class="cell green">Included</td>
+    <td class="cell green">Included</td>
+  </tr>
+  <tr>
+    <td style="color: black;">GCS</sup></td>
+    <td class="cell peach">Not supported</td>
+    <td class="cell peach">Not supported</td>
+    <td class="cell peach">Not supported</td>
+    <td class="cell peach">Not supported</td>
     <td class="cell green">Included</td>
   </tr>
   <tr>
@@ -82,7 +86,7 @@ Refer to the table below to determine if external blobstore support is included 
 In PAS v2.2 and later, BBR supports backing up and restoring versioned and unversioned S3
 or S3-compatible blobstores by default.
 For more information about configuring an S3 or S3-compatible blobstore,
-see [Configuring Load Balancing for PAS](../configure-lb.html).
+see [Configuring File Storage for PAS](../pas-file-storage.html#aws).
 
 <div class="note">
   <strong>Note:</strong>
@@ -96,9 +100,13 @@ see [Configuring Load Balancing for PAS](../configure-lb.html).
 
 To configure your Azure blobstore for backups, you must enable Soft Delete in your Azure Storage account. You can also enable Soft Delete for existing Azure storage accounts that were not initially created with Soft Delete enabled.
 For more information, see [Soft delete for Azure Storage blobs](https://docs.microsoft.com/en-us/azure/storage/blobs/storage-blob-soft-delete#quickstart)
-in the Microsoft documentation. 
+in the Microsoft documentation.
 
-After enabling Soft Delete, you can enable Azure blobstore backups in Ops Manager for new or existing blobstores. For more information, [Configuring Load Balancing for PAS](../configure-lb.html).
+After enabling Soft Delete, you can enable Azure blobstore backups in Ops Manager for new or existing blobstores. For more information, [Configuring File Storage for PAS](../pas-file-storage.html#azure).
 
 To save storage space and cost, Pivotal recommends that you configure a retention
-policy to permanently delete objects after a period of time.
+
+## <a id="gcs"></a> GCS Blobstores
+
+For more information about configuring a GCS blobstore,
+see [Configuring File Storage for PAS](../pas-file-storage.html#gcp).


### PR DESCRIPTION
- Updated file storage configuration for GCP
- Updated supported blobstores tables
- fixed links that did not link to relevant section

Related PRs:
- https://github.com/pivotal-cf/docs-ops-manager/pull/43
- https://github.com/pivotal-cf/terraforming-gcp/pull/140


Story here: https://www.pivotaltracker.com/story/show/158789077

[#158789077]

cc @aclevername 