### PR TITLE
Add explanation and new restore steps needed for selective backups

### DIFF
--- a/_max_droplets_packages_config.html.md.erb
+++ b/_max_droplets_packages_config.html.md.erb
@@ -6,9 +6,11 @@ In the **File Storage** pane, you determine where you would like to place your C
 
 1. To set the maximum number of recent, valid droplets your app can store, not including the package for the current droplet, enter a value in the **Maximum staged droplets per app** field. Pivotal recommends leaving the default value of `5`. However, you may want to lower the value if you have strict storage requirements and want to use less disk space.
 
-1. Under **Configure file storage backup level**, select which blobstores you want to exclude when backing up your file storage:
-	* **Complete file storage backup** includes all blobstores in your backups.
-	* **Exclude droplets from file storage backup** excludes droplets from your backups. For this option to take effect, you must restage <%= vars.product_name %>.
-	* **Exclude droplets and packages from file storage backup** excludes droplets and packages from your backups. For this option to take effect, you must run `cf push`.
+1. Under **Configure file storage backup level**, select what to backup from your blobstores:
+	* **Complete file storage backup** will include the entire blobstore (droplets, package and buildpacks).
+	* **Exclude droplets from file storage backup** excludes droplets from your backup.
+	* **Exclude droplets and packages from file storage backup** excludes droplets and packages from your backup.
+
+	To understand the risks and trade offs of excluding droplets and packages, see [File Storage Backup Level](./backup-restore/file-storage-backup-level.html)
 
 1. For **Configure your Cloud Controller's filesystem**, see [Configuring File Storage for PAS](./pas-file-storage.html). 

--- a/backup-restore/file-storage-backup-level.html.md.erb
+++ b/backup-restore/file-storage-backup-level.html.md.erb
@@ -3,15 +3,22 @@ title: File Storage Backup Level
 owner: RelEng
 ---
 
-In previous versions of PAS you were restricted to only being able to backup the entire blobstore. Now you have the option to configure what is backed in [File Storage](../configure-pas.html#file-storage) settings:
+As of PAS 2.7, operators can now configure their PAS file storage backups to exclude droplets or to exclude both droplets and packages. Operators can configure their PAS file storage in the following ways:
 
 * **Complete file storage backup**
 * **Exclude droplets from file storage backup**
 * **Exclude droplets and packages from file storage backup**
 
-The backing up of the blobstore is the biggest contributor to backup artifact sizes and the time taken to backup. With these new options you can trade off backup size and time for a longer RTO (Recovery time objective).
+To configure the PAS blobstore to exclude droplets or to exclude droplets and packages see [How to Configure PAS - File Storage](../configure-pas.html#file-storage).
 
-<table border="1" class="nice" >
+## <a id='file-storage-motivation'></a> Motivations for File Storage Configurations
+
+When considering configuration for your use case, the two main factors are backup artifact size and Recovery Time Objective (RTO). A smaller backup artifact would enable operators to take more frequent backups without incurring a significant amount of storage space or application downtime.
+
+A complete file storage backup results in the largest backup artifact size but results in the least amount of RTO. Whereas excluding droplets requires a restaging of all apps running in the PAS foundation and excluding droplets and packages requires every app to be pushed again.
+
+### <a id='blobstore-selective-backups-table'></a> Example Blobstore Proportions
+<table border="1" class="nice">
   <tr>
     <th>Name</th>
     <th>Portion of blobstore</th>
@@ -30,12 +37,39 @@ The backing up of the blobstore is the biggest contributor to backup artifact si
   </tr>
 </table>
 
+## <a id='complete-file-storage'></a> Complete File Storage Backup
 
-### Complete file storage backup
-This has been the default behaviour in all previous verisons of PAS. Droplets, packages and buildpacks will all be backed up. When your restore from a backup that contains the complete blobstore all of the applications will automatically come back into a "running" state. This is because PAS has been restored with the droplets and can automatically reschedule the apps without any manual intervention.
+The default behaviour in versions of PAS previous to 2.7 was to backup all blobs including droplets, packages and buildpacks. When restoring from a backup that contains the complete blobstore, applications will automatically come back into a "running" state. This is because PAS has been restored with the expected droplets and can automatically reschedule the apps without any manual intervention.
 
-### Exclude droplets from file storage backup
-If you choose to exclude droplets from file storage backup it will result in a smaller and faster backup, but with the trade off that when you run a restore all of the applications in the environment will not be in a `STOPPED` state. This is because the foundation does not have any droplets corresponding to the apps, but it does have the packages. In order to get the app running again you will have to manually run a `cf restage` against each app, this will instruct PAS recompile the droplet using the packages and deploy the new droplet. Having to manually run a `cf restage` against every app and recompile all of the apps will have a significant effect on the RTO.
+## <a id='exclude-droplets-file-storage'></a> Exclude Droplets from File Storage Backup
 
-### Exclude droplets and packages from file storage backup
-If you choose to exclude droplets and packages from file storage backup it will result in even smaller and faster backups than the alternative two option, but with an even greater RTO. After restoring all of the applications will be in a `STOPPED` state. This is because the foundation does not have the any droplets or packages corresponding to the apps. This means that in order for the applications be running again you will have to run a `cf push` for each app, this will upload the apps packages, compile a new droplet and deploy the new droplet. This has the same RTO as the `Exclude droplets from file storage backup` but with the added step of having to reupload all of the packages for every app.
+Excluding droplets from file storage backups will result in a smaller and faster backup but applications will be in a "stopped" state when restored. This is because the foundation does not have any droplets corresponding to the apps, but it does have the packages.
+
+In order to restore appplications, run the following command:
+
+```
+cf restage APP_NAME
+```
+
+This instructs PAS to recompile the droplet using the packages and deploy a new droplet. Having to manually run a `cf restage` against every app and recompile all of the apps will have a significant effect on the RTO.
+
+## <a id='exclude-droplets-packages-file-storage'></a> Exclude Droplets and Packages from File Storage Backup
+
+Excluding droplets and packages from file storage backup will result in even smaller and faster backups than the alternative two options but with an even greater RTO. Applications will be in a "stopped" state when restored because the foundation does not have  the droplets or packages corresponding to the apps.
+
+In order to restore appplications, run the following command:
+
+```
+cf push APP_NAME
+```
+
+This uploads the application packages, compiles and deploys a new droplet. This has the same RTO as the `Exclude droplets from file storage backup` but with the added step of having to reupload all of the packages for every app.
+
+## <a id='additional-considerations'></a> Additional Considerations
+
+In addition to considering backup size and RTO, consider the dependencies of applications in the PAS foundation.
+
+- Do certain applications require service instances to be running before being started?
+- Do certain applications have a dependency on start order?
+
+Because of these considerations, it may introduce complexity to the restore plan and increase RTO.

--- a/backup-restore/file-storage-backup-level.html.md.erb
+++ b/backup-restore/file-storage-backup-level.html.md.erb
@@ -1,0 +1,41 @@
+---
+title: File Storage Backup Level
+owner: RelEng
+---
+
+In previous versions of PAS you were restricted to only being able to backup the entire blobstore. Now you have the option to configure what is backed in [File Storage](../configure-pas.html#file-storage) settings:
+
+* **Complete file storage backup**
+* **Exclude droplets from file storage backup**
+* **Exclude droplets and packages from file storage backup**
+
+The backing up of the blobstore is the biggest contributor to backup artifact sizes and the time taken to backup. With these new options you can trade off backup size and time for a longer RTO (Recovery time objective).
+
+<table border="1" class="nice" >
+  <tr>
+    <th>Name</th>
+    <th>Portion of blobstore</th>
+  </tr>
+  <tr>
+    <td><strong>Buildpacks</strong></td>
+    <td>0-5%</td>
+  </tr>
+  <tr>
+    <td><strong>Packages</strong></td>
+    <td>15-25%</td>
+  </tr>
+  <tr>
+    <td><strong>Droplets</strong></td>
+    <td>70-80%</td>
+  </tr>
+</table>
+
+
+### Complete file storage backup
+This has been the default behaviour in all previous verisons of PAS. Droplets, packages and buildpacks will all be backed up. When your restore from a backup that contains the complete blobstore all of the applications will automatically come back into a "running" state. This is because PAS has been restored with the droplets and can automatically reschedule the apps without any manual intervention.
+
+### Exclude droplets from file storage backup
+If you choose to exclude droplets from file storage backup it will result in a smaller and faster backup, but with the trade off that when you run a restore all of the applications in the environment will not be in a `STOPPED` state. This is because the foundation does not have any droplets corresponding to the apps, but it does have the packages. In order to get the app running again you will have to manually run a `cf restage` against each app, this will instruct PAS recompile the droplet using the packages and deploy the new droplet. Having to manually run a `cf restage` against every app and recompile all of the apps will have a significant effect on the RTO.
+
+### Exclude droplets and packages from file storage backup
+If you choose to exclude droplets and packages from file storage backup it will result in even smaller and faster backups than the alternative two option, but with an even greater RTO. After restoring all of the applications will be in a `STOPPED` state. This is because the foundation does not have the any droplets or packages corresponding to the apps. This means that in order for the applications be running again you will have to run a `cf push` for each app, this will upload the apps packages, compile a new droplet and deploy the new droplet. This has the same RTO as the `Exclude droplets from file storage backup` but with the added step of having to reupload all of the packages for every app.

--- a/backup-restore/restore-pcf-bbr.html.md.erb
+++ b/backup-restore/restore-pcf-bbr.html.md.erb
@@ -409,7 +409,7 @@ For example, if you are using Redis for <%= vars.product_name %> v1.14, see [Usi
   <ul>
     <li>The BBR PAS restore command can take at least 15 minutes to complete.</li>
     <li>Pivotal recommends that you run it independently of the SSH session, so that the process can continue running even if your connection to the jumpbox fails. The command above uses <code>nohup</code> but you could also run the command in a <code>screen</code> or <code>tmux</code> session.</li>
-    <li>If the PAS file storage has been configured to selectively backup the blobstore, you may need to follow additional steps in order to restore your applications
+    <li>If the PAS file storage has been configured to selectively backup the blobstore, you may need to follow additional steps in order to restore your applications.</li>
   </ul>
 </div>
 

--- a/backup-restore/restore-pcf-bbr.html.md.erb
+++ b/backup-restore/restore-pcf-bbr.html.md.erb
@@ -409,6 +409,7 @@ For example, if you are using Redis for <%= vars.product_name %> v1.14, see [Usi
   <ul>
     <li>The BBR PAS restore command can take at least 15 minutes to complete.</li>
     <li>Pivotal recommends that you run it independently of the SSH session, so that the process can continue running even if your connection to the jumpbox fails. The command above uses <code>nohup</code> but you could also run the command in a <code>screen</code> or <code>tmux</code> session.</li>
+    <li>If the PAS file storage has been configured to selectively backup the blobstore, you may need to follow additional steps in order to restore your applications
   </ul>
 </div>
 
@@ -448,8 +449,32 @@ For example, if you are using Redis for <%= vars.product_name %> v1.14, see [Usi
 
 1. Click **Apply Changes** to deploy.
 
+### <a id='restore-apps'></a> Step 15: (Optional) Restore Applications
 
-### <a id='odb'></a> Step 15: (Optional) Restore On-Demand Service Instances
+This step is only required for a PAS file storage that has been configured to exclude droplets or to exclude droplets and packages.
+To understand the risks and trade offs of excluding droplets and packages, see [File Storage Backup Level](./backup-restore/file-storage-backup-level.html).
+
+#### <a id='restore-apps-droplets'></a> File Storage Excluding Droplets
+
+If you have applications in your PAS foundation, perform the following steps to return them to a running state:
+
+1. For each app, run:
+
+```
+cf restage APP_NAME
+```
+
+#### <a id='restore-apps-droplets-packages'></a> File Storage Excluding Droplets and Packages
+
+If you have applications in your PAS foundation, perform the following steps to return them to a running state:
+
+1. For each app, run:
+
+```
+cf push APP_NAME [OPTIONAL-FLAGS]
+```
+
+### <a id='odb'></a> Step 16: (Optional) Restore On-Demand Service Instances
 
 If you have on-demand service instances provisioned by an on-demand service broker, perform the following steps to restore them after successfully restoring PAS:
 
@@ -470,7 +495,7 @@ If you have on-demand service instances provisioned by an on-demand service brok
 1. Any app on PAS bound to an on-demand service instance might need to be restarted to start consuming the restored on-demand service instances.
 
 
-### <a id='non-tiles'></a> Step 16: (Optional) Restore Non-Tile Deployments
+### <a id='non-tiles'></a> Step 17: (Optional) Restore Non-Tile Deployments
 
 If you have any deployments that were deployed manually with the BOSH Director rather than through an Ops Manager tile, perform the following steps to restore the VMs.
 
@@ -532,7 +557,7 @@ The process state for all VMs should show as `running`.
 
 This section provides the steps you need to perform after restoring your <%= vars.product_name %> backup with BBR.
 
-### <a id='removing-disks'></a> Step 17: Remove Unused Disks
+### <a id='removing-disks'></a> Step 18: Remove Unused Disks
 
 <p class="note warning"><strong>Warning:</strong> This is a very destructive operation.</p>
 


### PR DESCRIPTION
This story is for PAS 2.7 only so far.

It includes:
- a new page for configuring file storage for PAS
- a new optional step for restoring PAS if selective backups are configured.

Story here: https://www.pivotaltracker.com/story/show/164693611