### PR TITLE
Make clear that PAS tile needs to be selected for PAS restore

### DIFF
--- a/backup-restore/restore-pcf-bbr.html.md.erb
+++ b/backup-restore/restore-pcf-bbr.html.md.erb
@@ -390,7 +390,7 @@ for each stemcell that is different from the already uploaded PAS stemcell.
 
 1. Click **Review Pending Changes**.
 
-1. Review your changes. For more information, see [Reviewing Pending Product Changes](../review-pending-changes.html).
+1. Review your changes and ensure the PAS tile is selected (other tiles are optional). For more information, see [Reviewing Pending Product Changes](../review-pending-changes.html).
 
 1. Click **Apply Changes** to redeploy.
 


### PR DESCRIPTION
Story here: https://www.pivotaltracker.com/story/show/167141964

This clarification is required for all versions for PAS as of PCF 2.2.