### PR TITLE
Corrected bosh command for bosh upload-stemcell

### DIFF
--- a/cloudform-om-ebs-config.html.md.erb
+++ b/cloudform-om-ebs-config.html.md.erb
@@ -60,7 +60,7 @@ key/12345678-9012-3456-7890-123456789012
 		1. Enter the `bosh stemcells` and `bosh deployments` commands into the command line. Record the stemcell names that BOSH-deployed VMs are using.
 		**Encrypt BOSH-deployed VMs**
 		1. Go to the folder `var/tempest/stemcells` in the SSHed Ops Manager VM.
-		1. Enter the `bosh upload stemcell STEMCELL_NAME --fix` command into the command line for each stemcell to enforce the BOSH Director, encrypt the stemcells, and re-upload them.
+		1. Enter the `bosh upload-stemcell STEMCELL_NAME --fix` command into the command line for each stemcell to enforce the BOSH Director, encrypt the stemcells, and re-upload them.
 	1. Reset Persistent Disks and Recreate VMs.
 		1. Select the **Director Config** pane.
 		1. Enable **Recreate All VMs**.


### PR DESCRIPTION
Document lists `bosh upload stemcell` as the command in line 63, it should be `bosh upload-stemcell`