### PR TITLE
Update UAA docs to explain the new uri encoding option

### DIFF
--- a/_uaa.html.md.erb
+++ b/_uaa.html.md.erb
@@ -45,4 +45,11 @@ In the **UAA** pane, you configure the User Account and Authentication server.
 
 1. (Optional) The **Proxy IPs regular expression** field contains a pipe-separated set of regular expressions that UAA considers to be reverse proxy IP addresses. UAA respects the `x-forwarded-for` and `x-forwarded-proto` headers coming from IP addresses that match these regular expressions. To configure UAA to respond properly to Gorouter or HAProxy requests coming from a public IP address, append a regular expression or regular expressions to match the public IP address.
 
+1. (Optional) The **Client basic auth compatibility mode** checkbox governs how the UAA will process client ids/secrets when sent to the UAA in a Basic Auth header.
+  * If **checked**, the UAA will not require URL-encoded client id/secret.
+    * This was the behavior of the UAA prior to [v74.0.0](https://github.com/cloudfoundry/uaa-release/releases/tag/v74.0.0).
+    * Clients may choose to provide URL-encoded client id/secret by sending header `X-CF-ENCODED-CREDENTIALS=true`.
+  * If **not checked**, the UAA will require client ids/secrets to be URL encoded as per [RFC6749](https://tools.ietf.org/html/rfc6749#section-2.3.1).
+  * It is recommended that clients URL encode basic auth credentials and send the `X-CF-ENCODED-CREDENTIALS=true` header to be compatible with either mode.
+
 1. Click **Save**.


### PR DESCRIPTION
This will be a change going into PAS 2.8.

Related PAS Request: https://github.com/pivotal/pas-requests/issues/621