### PR TITLE
Update vsphere-nsx-t.html.md.erb

### DIFF
--- a/vsphere-nsx-t.html.md.erb
+++ b/vsphere-nsx-t.html.md.erb
@@ -25,7 +25,7 @@ Before deploying PAS with NSX-T networking, you must have the following:
 * BOSH and Ops Manager installed and configured on vSphere. See [Deploying Ops Manager on vSphere](/platform/ops-manager/<%= vars.current_major_version.sub('.', '-') %>/vsphere/deploy.html) and [Configuring BOSH Director on vSphere](/platform/ops-manager/<%= vars.current_major_version.sub('.', '-') %>/vsphere/config.html).
 * The [VMware NSX-T Container Plug-in for PCF tile](https://network.pivotal.io/products/vmware-nsx-t) downloaded from Pivotal Network and imported to the Ops Manager **Installation Dashboard**. See [Adding and Importing Products](./add-delete.html#add-import) for how to download and import Pivotal products to the **Installation Dashboard**.
 * The [PAS tile](https://network.pivotal.io/products/elastic-runtime) downloaded from Pivotal Network and imported to the Ops Manager **Installation Dashboard**. The PAS tile must be in one of the following two states:
-  * Not deployed yet; you have not yet clicked **Review Pending Changes**, then **Apply Changes** on this version of PAS.
+  * Configured but not deployed yet; you have not yet clicked **Review Pending Changes**, then **Apply Changes** on this version of PAS.
   * Deployed previously, with the **Networking** pane > **Container Network Interface Plugin** set to **External**.
   <p class="note"><strong>Note:</strong> Deploying PAS with its Container Network Interface (CNI) set to **Silk** configures Diego cells to use an internally-managed container network. Subsequently switching the CNI interface to **External** NSX-T leads to errors.</p>
 


### PR DESCRIPTION
Added "configured" as a state description to make it clear that the PAS tile is required when deploying NSX-T

This is valid for all versions of NSX-T install docs.

cc: @ameowlia