### PR TITLE
Add recommendation to clean-up BOSH director prior to backup

### DIFF
--- a/backup-restore/backup-pcf-bbr.html.md.erb
+++ b/backup-restore/backup-pcf-bbr.html.md.erb
@@ -36,6 +36,10 @@ Pivotal recommends:
 
 * Back up frequently, especially before making any changes to your <%= vars.platform_name %> deployment, such as the configuration of any tiles in Ops Manager.
 
+* For BOSH v270.0 and above, you can prune the BOSH blobstore by running `bosh clean-up --all` prior to running a backup of the BOSH director. This will remove all unused resources including packages compiled against older stemcell versions. This will result in a smaller, faster backup of the BOSH director if a lot of unused resources have accumulated over time. For more information see [Clean-Up](https://bosh.io/docs/cli-v2/#clean-up).
+
+<p class="note"><strong>Note:</strong>The command `bosh clean-up --all` is a destructive operation and can remove resources that are unused but needed. For example, if an On-Demand Service Broker is deployed, the releases needed to create a service instance will be categorised as unused if no service instances have been created.</p>
+
 
 ## <a id='supported'></a> Supported Components
 

--- a/backup-restore/backup-pcf-bbr.html.md.erb
+++ b/backup-restore/backup-pcf-bbr.html.md.erb
@@ -36,7 +36,7 @@ Pivotal recommends:
 
 * Back up frequently, especially before making any changes to your <%= vars.platform_name %> deployment, such as the configuration of any tiles in Ops Manager.
 
-* For BOSH v270.0 and above (currently available in PCF 2.7), you can prune the BOSH blobstore by running `bosh clean-up --all` prior to running a backup of the BOSH director. This will remove all unused resources including packages compiled against older stemcell versions. This will result in a smaller, faster backup of the BOSH director if a lot of unused resources have accumulated over time. For more information see [Clean-Up](https://bosh.io/docs/cli-v2/#clean-up).
+* You can prune the BOSH blobstore by running `bosh clean-up --all` before you run a backup of the BOSH Director. The command removes all unused resources including packages compiled against older stemcell versions. If a lot of unused resources have accumulated over time, you create a smaller, faster backup of the BOSH Director. For more information see [Clean-Up](https://bosh.io/docs/cli-v2/#clean-up) in the BOSH documentation.
 
 <p class="note"><strong>Note:</strong>The command `bosh clean-up --all` is a destructive operation and can remove resources that are unused but needed. For example, if an On-Demand Service Broker is deployed <strong>and</strong> no service instances have been created, the releases needed to create a service instance will be categorised as unused.</p>
 

--- a/backup-restore/backup-pcf-bbr.html.md.erb
+++ b/backup-restore/backup-pcf-bbr.html.md.erb
@@ -36,9 +36,9 @@ Pivotal recommends:
 
 * Back up frequently, especially before making any changes to your <%= vars.platform_name %> deployment, such as the configuration of any tiles in Ops Manager.
 
-* For BOSH v270.0 and above, you can prune the BOSH blobstore by running `bosh clean-up --all` prior to running a backup of the BOSH director. This will remove all unused resources including packages compiled against older stemcell versions. This will result in a smaller, faster backup of the BOSH director if a lot of unused resources have accumulated over time. For more information see [Clean-Up](https://bosh.io/docs/cli-v2/#clean-up).
+* For BOSH v270.0 and above (currently available in PCF 2.7), you can prune the BOSH blobstore by running `bosh clean-up --all` prior to running a backup of the BOSH director. This will remove all unused resources including packages compiled against older stemcell versions. This will result in a smaller, faster backup of the BOSH director if a lot of unused resources have accumulated over time. For more information see [Clean-Up](https://bosh.io/docs/cli-v2/#clean-up).
 
-<p class="note"><strong>Note:</strong>The command `bosh clean-up --all` is a destructive operation and can remove resources that are unused but needed. For example, if an On-Demand Service Broker is deployed, the releases needed to create a service instance will be categorised as unused if no service instances have been created.</p>
+<p class="note"><strong>Note:</strong>The command `bosh clean-up --all` is a destructive operation and can remove resources that are unused but needed. For example, if an On-Demand Service Broker is deployed <strong>and</strong> no service instances have been created, the releases needed to create a service instance will be categorised as unused.</p>
 
 
 ## <a id='supported'></a> Supported Components


### PR DESCRIPTION
This informs operators that they can run a clean-up operation prior to performing a BOSH director backup. It is accompanied by a warning note that this operation is destructive and to be aware of the potential damage.

Story [here](https://www.pivotaltracker.com/story/show/166407001)