### PR TITLE
Update docs for locked fields under S3 Blobstore

### DIFF
--- a/lock-on-deploy.html.md.erb
+++ b/lock-on-deploy.html.md.erb
@@ -65,9 +65,6 @@ In the **Blobstore Location** section:
 
 * **S3 Endpoint** in the **S3 Compatible Blobstore** section
 * **Bucket Name** in the **S3 Compatible Blobstore** section
-* **V2 Signature** in the **S3 Compatible Blobstore** section
-* **V4 Signature** in the **S3 Compatible Blobstore** section
-	* **Region** in the **S3 Compatible Blobstore** > **V4 Signature** section
 
 <p class="note"><strong>Note:</strong> Changes to the <em>Internal</em> or <em>S3 Compatible Blobstore</em> radio buttons in the <em>Blobstore Location</em> section will not affect a deployed Ops Manager.</p>
 


### PR DESCRIPTION
Starting in Ops Manager 2.9, the S3 Blobstore signature (v2 and v4) as
well as the region are no longer locked after an Apply Changes.

Signed-off-by: Brian Upton <bupton@pivotal.io>