### PR TITLE
Update docs to reflect that Alana can now update blobstore location

### DIFF
--- a/lock-on-deploy.html.md.erb
+++ b/lock-on-deploy.html.md.erb
@@ -47,8 +47,6 @@ In the **Blobstore Location** section:
 
 * **S3 Endpoint** in the **S3 Compatible Blobstore** section
 * **Bucket Name** in the **S3 Compatible Blobstore** section
-* **Access Key** in the **S3 Compatible Blobstore** section
-* **Secret Key** in the **S3 Compatible Blobstore** section
 * **V2 Signature** in the **S3 Compatible Blobstore** > **S3 Signature Version** section
 * **V4 Signature** in the **S3 Compatible Blobstore** > **S3 Signature Version** section
 * **Region** in the **S3 Compatible Blobstore** > **S3 Signature Version** section

--- a/lock-on-deploy.html.md.erb
+++ b/lock-on-deploy.html.md.erb
@@ -43,6 +43,18 @@ In the **Assign AZs and Networks** pane, you can unlock the following fields aft
 
 * The **Singleton Availability Zone** dropdown
 
+In the **Blobstore Location** section:
+
+* **S3 Endpoint** in the **S3 Compatible Blobstore** section
+* **Bucket Name** in the **S3 Compatible Blobstore** section
+* **Access Key** in the **S3 Compatible Blobstore** section
+* **Secret Key** in the **S3 Compatible Blobstore** section
+* **V2 Signature** in the **S3 Compatible Blobstore** > **S3 Signature Version** section
+* **V4 Signature** in the **S3 Compatible Blobstore** > **S3 Signature Version** section
+* **Region** in the **S3 Compatible Blobstore** > **S3 Signature Version** section
+* **Backup Bucket Region** in the **S3 Compatible Blobstore** > **S3 Backup Strategy** section
+* **Backup Bucket Name** in the **S3 Compatible Blobstore** > **S3 Backup Strategy** section
+
 ### <a id='product-tiles'></a>Unlockable Fields in Product Tiles
 
 Product tiles also have unlockable fields.
@@ -60,14 +72,6 @@ This section describes the fields that lock during deployment and cannot be unlo
 ### <a id='director-tile-locked'></a>Permanently-Locked Fields in the Director tile
 
 In the **Director Config** pane, the following fields lock permanently after deployment:
-
-In the **Blobstore Location** section:
-
-* **S3 Endpoint** in the **S3 Compatible Blobstore** section
-* **Bucket Name** in the **S3 Compatible Blobstore** section
-* **V2 Signature** in the **S3 Compatible Blobstore** section
-* **V4 Signature** in the **S3 Compatible Blobstore** section
-	* **Region** in the **S3 Compatible Blobstore** > **V4 Signature** section
 
 <p class="note"><strong>Note:</strong> Changes to the <em>Internal</em> or <em>S3 Compatible Blobstore</em> radio buttons in the <em>Blobstore Location</em> section will not affect a deployed Ops Manager.</p>
 

--- a/lock-on-deploy.html.md.erb
+++ b/lock-on-deploy.html.md.erb
@@ -45,6 +45,8 @@ In the **Assign AZs and Networks** pane, you can unlock the following fields aft
 
 In the **Blobstore Location** section:
 
+* **The blobstore type itself can be changed**
+
 * **S3 Endpoint** in the **S3 Compatible Blobstore** section
 * **Bucket Name** in the **S3 Compatible Blobstore** section
 * **V2 Signature** in the **S3 Compatible Blobstore** > **S3 Signature Version** section


### PR DESCRIPTION
Also added fields that seemed to be missing. This is for Ops Manager 2.9.

[#170009155] Operators should be able to switch Blobstore location in Director Config in Advanced Mode