### PR TITLE
Update docs around External MySQL Database fields + advanced mode

### DIFF
--- a/lock-on-deploy.html.md.erb
+++ b/lock-on-deploy.html.md.erb
@@ -39,7 +39,7 @@ In the **CredHub Encryption Provider** fields, when you are using a Luna HSM, yo
 * **HSM Port Address**
 * **Partition Serial Number**
 
-In the **Database Location** fields, when you are using an External MySQL Database, you can unlock the following fields after deployment:
+In the **Database Location** fields, when you are using an external MySQL database, you can unlock the following fields after deployment:
 
 * **Host**
 * **Port**

--- a/lock-on-deploy.html.md.erb
+++ b/lock-on-deploy.html.md.erb
@@ -39,6 +39,12 @@ In the **CredHub Encryption Provider** fields, when you are using a Luna HSM, yo
 * **HSM Port Address**
 * **Partition Serial Number**
 
+In the **Database Location** fields, when you are using an External MySQL Database, you can unlock the following fields after deployment:
+
+* **Host**
+* **Port**
+* **Database**
+
 In the **Assign AZs and Networks** pane, you can unlock the following fields after deployment:
 
 * The **Singleton Availability Zone** dropdown
@@ -71,16 +77,6 @@ In the **Blobstore Location** section:
 	* **Region** in the **S3 Compatible Blobstore** > **V4 Signature** section
 
 <p class="note"><strong>Note:</strong> Changes to the <em>Internal</em> or <em>S3 Compatible Blobstore</em> radio buttons in the <em>Blobstore Location</em> section will not affect a deployed Ops Manager.</p>
-
-In the Database Location section:
-
-* **Host** in the **External MySQL Database** section
-* **Port** in the **External MySQL Database** section
-* **Username** in the **External MySQL Database** section
-* **Password** in the **External MySQL Database** section
-* **Database** in the **External MySQL Database** section
-
-<p class="note"><strong>Note:</strong> Changes to the <em>Internal</em> or <em>External MySQL Database</em> radio buttons in the <em>Database Location</em> section will not affect a deployed Ops Manager.</p>
 
 In the **Create Availability Zone** pane, the following fields lock permanently after deployment:
 


### PR DESCRIPTION
In the latest Ops Manager 2.7 patch, we changed the Username field under
External MySQL Database section to always be unlocked, even after an
Apply Changes. A previous change was already made to unlock the Password
field.

Additionally, the Host, Port, and Database fields can now be edited
while in Advanced Mode.

Signed-off-by: Kenneth Lakin <klakin@pivotal.io>