### PR TITLE
Document permanently locked CredHub fields in Ops Manager 2.9

### DIFF
--- a/lock-on-deploy.html.md.erb
+++ b/lock-on-deploy.html.md.erb
@@ -61,6 +61,13 @@ This section describes the fields that lock during deployment and cannot be unlo
 
 In the **Director Config** pane, the following fields lock permanently after deployment:
 
+In the **CredHub Encryption Provider** section:
+
+* **Internal** or **Luna HSM**
+* **Encryption Key Name** in the **Luna HSM** section
+* **Provider Partition** in the **Luna HSM** section
+* **Provider Partition Password** in the **Luna HSM** section
+
 In the **Blobstore Location** section:
 
 * **S3 Endpoint** in the **S3 Compatible Blobstore** section


### PR DESCRIPTION
Signed-off-by: Kenneth Lakin <klakin@pivotal.io>