### PR TITLE
[2.5] Remove incorrect reference to backup of uaa DB in director backup

### DIFF
--- a/backup-restore/backup-pcf-bbr.html.md.erb
+++ b/backup-restore/backup-pcf-bbr.html.md.erb
@@ -55,7 +55,7 @@ For guidance about backing up unsupported databases and blobstores, see [Unsuppo
 
 BBR can back up and restore the BOSH Director configured with:
 
-* An internal PostgreSQL database or a supported external database. As part of backing up the BOSH Director, BBR backs up the BOSH UAA database and the CredHub database. For a list of supported external databases, see the [Supported External Databases](https://docs.cloudfoundry.org/bbr/cf-backup.html#supported-external-databases) section of _Configuring Cloud Foundry for BOSH Backup and Restore_ in the Cloud Foundry documentation.
+* An internal PostgreSQL database or a supported external database. As part of backing up the BOSH Director, BBR backs up the CredHub database. For a list of supported external databases, see the [Supported External Databases](https://docs.cloudfoundry.org/bbr/cf-backup.html#supported-external-databases) section of _Configuring Cloud Foundry for BOSH Backup and Restore_ in the Cloud Foundry documentation.
 
 * An internal blobstore or an external versioned S3 blobstore.
 


### PR DESCRIPTION
We didn't start backing up UAA as part of the bosh director until 2.8, removing incorrect statement from 2.5.

[#169366608]