### PR TITLE
clarify bosh log-in Director credentials source

### DIFF
--- a/trouble-advanced.html.md.erb
+++ b/trouble-advanced.html.md.erb
@@ -199,7 +199,7 @@ For example:
 
 #### <a id='uaa-bosh'></a> Log In to the BOSH Director VM with UAA
 
-1. Retrieve the Director password from the **BOSH Director > Credentials** tab. Alternatively, launch a browser and visit `https://OPS-MANAGER-FQDN/api/v0/deployed/director/credentials/director_credentials` to obtain the password. Replace `OPS-MANAGER-FQDN` with the fully qualified domain name of Ops Manager.
+1. Retrieve the Director username and password from the **BOSH Director > Credentials tab > "Director Credentials" link**. Alternatively, launch a browser and visit `https://OPS-MANAGER-FQDN/api/v0/deployed/director/credentials/director_credentials` to obtain the password. Replace `OPS-MANAGER-FQDN` with the fully qualified domain name of Ops Manager.
 
 1. Run `bosh -e MY-ENV log-in` to log in to the BOSH Director VM. Replace `MY-ENV` with the alias for your BOSH Director. For example:
     <pre class='terminal'>$ bosh -e gcp log-in</pre>


### PR DESCRIPTION
Simply going to the Credentials tab in the UI doesn't make it obvious which credentials are the source for the director username and password. This change spells it out explicitly.