### PR TITLE
`target` should be `uaac target`

### DIFF
--- a/ops-man-api.html.md.erb
+++ b/ops-man-api.html.md.erb
@@ -166,7 +166,7 @@ To log in to the Ops Manager VM and retrieve your token, do the following:
 
     For example:
 
-    <pre class="terminal">$ target https://my-opsmanager.example.com/uaa</pre>
+    <pre class="terminal">$ uaac target https://my-opsmanager.example.com/uaa</pre>
 
 1. Depending on whether your Ops Manager UAA is internal or external, run a command to retrieve your UAA token and respond to the authentication prompts as follows:
   * **Internal**


### PR DESCRIPTION
`target`, by itself, errors:

```
bash: target: command not found
```